### PR TITLE
docs: Split the Python SDK reference docs 

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -42,12 +42,14 @@
       "pages": [
         {
           "group": "Python SDK Reference",
+          "icon": "python",
           "pages": [
             "sdk-api/python/reference",
             {
               "group": "Wrappers",
               "icon": "box",
               "pages": [
+                "sdk-api/python/wrappers/wrappers-overview",
                 "sdk-api/python/wrappers/openai",
                 "sdk-api/python/wrappers/langchain"
               ]
@@ -56,8 +58,8 @@
               "group": "Experimentation",
               "icon": "flask",
               "pages": [
-                "sdk-api/python/experimentation/datasets",
-                "sdk-api/python/experimentation/experimentation"
+                "sdk-api/python/experimentation/experimentation",
+                "sdk-api/python/experimentation/datasets"
               ]
             },
             "sdk-api/python/prompts"

--- a/sdk-api/python/experimentation/datasets.mdx
+++ b/sdk-api/python/experimentation/datasets.mdx
@@ -1,9 +1,6 @@
 ---
 title: Datasets
-icon: "database"
 ---
-
-## Datasets
 
 Create a dataset and add data to it:
 

--- a/sdk-api/python/experimentation/experimentation.mdx
+++ b/sdk-api/python/experimentation/experimentation.mdx
@@ -1,9 +1,6 @@
 ---
-title: Experimentation
-icon: "flask"
+title: Overview
 ---
-
-## Experimentation
 
 Evaluating a runner function against an existing dataset:
 

--- a/sdk-api/python/prompts.mdx
+++ b/sdk-api/python/prompts.mdx
@@ -1,9 +1,6 @@
 ---
 title: Prompts
-icon: "message"
 ---
-
-## Prompts
 
 Create and use a prompt template:
 

--- a/sdk-api/python/reference.mdx
+++ b/sdk-api/python/reference.mdx
@@ -1,9 +1,6 @@
 ---
-title: Python SDK Overview
-icon: "python"
+title: Overview
 ---
-
-## Introduction
 
 The Python SDK allows you to log all prompts, responses, and statistics around your LLM usage. There are three main ways to log your application:
 

--- a/sdk-api/python/wrappers/langchain.mdx
+++ b/sdk-api/python/wrappers/langchain.mdx
@@ -1,9 +1,37 @@
 ---
-title: Langchain Integration
-icon: "link"
+title: LangChain Integration
 ---
 
-## Langchain integration (via their callbacks API):
+The Galileo LangChain integration allows you to automatically log all LangChain interactions with LLMs, including prompts, responses, and performance metrics. This integration works through LangChain's callbacks API, making it easy to add logging to your existing LangChain applications with minimal code changes.
+
+## Installation
+
+First, make sure you have the Galileo SDK and LangChain installed:
+
+```bash
+pip install galileo langchain
+```
+
+## Setup
+
+Create or update a `.env` file with your Galileo API key and other optional settings:
+
+```env
+# Scoped to an Organization
+GALILEO_API_KEY=...
+
+# Optional, if you're not using the multi-tenant cluster
+# GALILEO_CONSOLE_URL=https://console.experimental-aws.rungalileo.io/
+
+# Optional, set a default Project
+GALILEO_PROJECT=...
+# Optional, set a default Log Stream
+GALILEO_LOG_STREAM=...
+```
+
+## Basic Usage
+
+The integration is based on the `GalileoCallback` class, which implements LangChain's callback interface. To use it, simply create an instance of the callback and pass it to your LangChain components:
 
 ```python
 from galileo.handlers.langchain import GalileoCallback
@@ -13,6 +41,17 @@ callback = GalileoCallback()
  
 llm = ChatOpenAI(model="gpt-4o", callbacks=[callback])
 ```
+
+When initializing the `GalileoCallback`, you can optionally specify a project name and log stream:
+
+```python
+# Log to a specific project and log stream
+callback = GalileoCallback(project_name="my-project", log_stream="my-log-stream")
+```
+
+## Using with LangChain Chains
+
+You can also use the callback with LangChain chains. Make sure to pass the callback to both the LLM and the chain:
 
 ```python
 from galileo.handlers.langchain import GalileoCallback
@@ -33,3 +72,44 @@ result = llm_math.invoke(
             },
         },
     )
+```
+
+## Advanced Usage
+
+The `GalileoCallback` captures various LangChain events, including:
+
+- LLM starts and completions
+- Chat model interactions
+- Chain executions
+- Tool calls
+- Retriever operations
+- Agent actions
+
+For each of these events, the callback logs relevant information to Galileo, such as:
+
+- Input prompts and messages
+- Output responses
+- Model information
+- Timing data
+- Token usage
+- Error information (if any)
+
+### Adding Metadata
+
+You can add custom metadata to your logs by including it in the `metadata` parameter when invoking a chain or LLM:
+
+```python
+result = chain.invoke(
+    "Your input here",
+    {
+        "callbacks": [handler],
+        "metadata": {
+            "user_id": "user-123",
+            "session_id": "session-456",
+            "custom_field": "custom value"
+        }
+    }
+)
+```
+
+This metadata will be attached to the logs in Galileo, making it easier to filter and analyze your data.

--- a/sdk-api/python/wrappers/openai.mdx
+++ b/sdk-api/python/wrappers/openai.mdx
@@ -1,9 +1,6 @@
 ---
 title: OpenAI Wrapper
-icon: "openai"
 ---
-
-# OpenAI Wrapper
 
 The OpenAI wrapper is the simplest way to integrate Galileo logging into your application. By using Galileo's OpenAI wrapper instead of importing the OpenAI library directly, you can automatically log all prompts, responses, and statistics without any additional code changes.
 
@@ -106,7 +103,7 @@ with galileo_context(project="my-project", log_stream="my-log-stream"):
 
 ## Advanced Usage
 
-The OpenAI wrapper supports all the same functionality as the original OpenAI library, including:
+The OpenAI wrapper is intended to support all the same functionality as the original OpenAI library, including:
 
 - Chat completions
 - Text completions
@@ -114,12 +111,11 @@ The OpenAI wrapper supports all the same functionality as the original OpenAI li
 - Image generation
 - Audio transcription and translation
 
-For each of these, the wrapper automatically logs the relevant information to Galileo, making it easy to track and analyze your AI application's performance.
+For each of these, the wrapper will automatically log the relevant information to Galileo, making it easy to track and analyze your AI application's performance.
 
 ## Benefits of Using the Wrapper
 
 - **Zero-config logging**: No need to add logging code throughout your application
 - **Complete visibility**: All prompts and responses are automatically captured
 - **Minimal code changes**: Simply change your import statement
-- **Full compatibility**: Works with all OpenAI API features
 - **Automatic tracing**: Creates spans and traces without manual setup

--- a/sdk-api/python/wrappers/wrappers-overview.mdx
+++ b/sdk-api/python/wrappers/wrappers-overview.mdx
@@ -1,0 +1,23 @@
+---
+title: Overview
+---
+
+Galileo wrappers automatically capture prompts, responses, and performance metrics without requiring you to add explicit logging code throughout your application.
+
+Just import the wrapper anywhere you were using the original library (ex. openai)!
+
+## Available Wrappers
+
+Galileo currently supports the following wrappers:
+
+- [**OpenAI Wrapper**](./openai) - A drop-in replacement for the OpenAI library that automatically logs all prompts, responses, and statistics.
+- [**LangChain Integration**](./langchain) - A callback-based integration for LangChain that logs all LLM interactions within your LangChain workflows.
+
+## Alternative Methods of Logging
+
+If you're using an LLM library that doesn't have a dedicated Galileo wrapper, you can still log your application using:
+
+1. **The `@log` Decorator** - Add the `@log` decorator to functions that call LLMs to automatically capture inputs and outputs.
+2. **Direct Use of the `GalileoLogger` Class** - For more control, you can use the base logger class directly.
+
+For detailed information on these alternative logging methods, see the [Python SDK Overview](../reference).


### PR DESCRIPTION
Splits up the Python SDK Reference into sub-pages (using icons for folders). 
Added more description for what the wrappers were doing. 
Added a wrapper page for OpenAI and LangChain (Not fully sure if LangChain is exactly a wrapper, open to suggestions on that front).
Added overviews to help readers navigate to the exact right page for their situation.

Still need to update the Experiments / Datasets pages as I understand the workflow there better!