### PR TITLE
docs: Remove redundant section headers in TypeScript SDK documentation

### DIFF
--- a/sdk-api/typescript/datasets.mdx
+++ b/sdk-api/typescript/datasets.mdx
@@ -3,8 +3,6 @@ title: Datasets
 icon: "database"
 ---
 
-# Datasets
-
 Galileo Datasets allow you to create, manage, and version collections of data for testing and evaluating your LLM applications.
 
 ## Creating a Dataset

--- a/sdk-api/typescript/experiments.mdx
+++ b/sdk-api/typescript/experiments.mdx
@@ -3,8 +3,6 @@ title: Experiments
 icon: "flask"
 ---
 
-# Experiments
-
 Galileo Experiments allow you to evaluate and improve your LLM applications by running tests against datasets and measuring performance using various metrics.
 
 ## Running an Experiment with a Function

--- a/sdk-api/typescript/logging/galileo-context.mdx
+++ b/sdk-api/typescript/logging/galileo-context.mdx
@@ -3,8 +3,6 @@ title: Galileo Context
 icon: "box"
 ---
 
-# Galileo Context
-
 The `withGalileo` context wrapper allows you to wrap a block of code in a trace. It also allows you to direct logs to a specific project and log stream - this will override your environment variables.
 
 ## Use Cases
@@ -108,4 +106,4 @@ Creates a context in which all LLM calls and observed functions are logged as sp
 
 #### Returns
 
-The return value of the function. 
+The return value of the function.

--- a/sdk-api/typescript/logging/galileo-logger.mdx
+++ b/sdk-api/typescript/logging/galileo-logger.mdx
@@ -3,8 +3,6 @@ title: Galileo Logger
 icon: "terminal"
 ---
 
-# Galileo Logger
-
 The `GalileoLogger` is a low-level API for logging traces and spans to Galileo. It provides more control over the logging process than the higher-level wrappers and context managers.
 
 ## Usage

--- a/sdk-api/typescript/logging/observe-wrapper.mdx
+++ b/sdk-api/typescript/logging/observe-wrapper.mdx
@@ -3,8 +3,6 @@ title: Observe Wrapper
 icon: "eye"
 ---
 
-# Observe Wrapper
-
 The `observe` wrapper is a utility function that allows you to wrap a function and log its execution as a span in a trace. It serves two main purposes:
 
 1. It tells our logger to wrap the function contents as a span (you can specify the type in the first argument - by default a workflow span is created).
@@ -134,4 +132,4 @@ Wraps a function and logs its execution as a span in a trace.
 
 #### Returns
 
-The return value of the wrapped function. 
+The return value of the wrapped function.

--- a/sdk-api/typescript/overview.mdx
+++ b/sdk-api/typescript/overview.mdx
@@ -3,8 +3,6 @@ title: TypeScript SDK Overview
 icon: "node-js"
 ---
 
-# Galileo TypeScript SDK
-
 The Galileo TypeScript SDK provides a comprehensive set of tools for logging, evaluating, and experimenting with LLM applications. It's designed to be easy to use while providing powerful features for monitoring and improving your AI applications.
 
 ## Installation

--- a/sdk-api/typescript/prompts.mdx
+++ b/sdk-api/typescript/prompts.mdx
@@ -3,8 +3,6 @@ title: Prompts
 icon: "message"
 ---
 
-# Prompts
-
 Galileo Prompts allow you to create, version, and test prompt templates for your LLM applications.
 
 ## Creating a Prompt Template

--- a/sdk-api/typescript/wrappers/openai.mdx
+++ b/sdk-api/typescript/wrappers/openai.mdx
@@ -3,8 +3,6 @@ title: OpenAI Wrapper
 icon: "openai"
 ---
 
-# OpenAI Wrapper
-
 The OpenAI wrapper provides a simple way to automatically log all OpenAI API calls to Galileo. It wraps the official OpenAI Node.js client and intercepts all API calls to log them.
 
 ## Installation
@@ -119,4 +117,4 @@ Wraps an OpenAI client instance to automatically log all API calls to Galileo.
 
 #### Returns
 
-A wrapped OpenAI client instance that automatically logs all API calls to Galileo. 
+A wrapped OpenAI client instance that automatically logs all API calls to Galileo.

--- a/sdk-api/typescript/wrappers/wrappers-overview.mdx
+++ b/sdk-api/typescript/wrappers/wrappers-overview.mdx
@@ -3,8 +3,6 @@ title: Wrappers Overview
 icon: "box"
 ---
 
-# Wrappers Overview
-
 Galileo provides wrappers for popular LLM providers and frameworks to make it easy to integrate logging into your existing applications. These wrappers automatically capture LLM interactions and log them to Galileo.
 
 ## Available Wrappers


### PR DESCRIPTION
Cleaned up documentation by removing repeated section headers from MDX files, improving readability and consistency across TypeScript SDK reference pages