### PR TITLE
Add example SyncCodeGroups component

### DIFF
--- a/snippets/SyncCodeGroups.mdx
+++ b/snippets/SyncCodeGroups.mdx
@@ -5,8 +5,11 @@ export const SyncCodeGroups = ({ ignoreErrors = false }) => {
      * This component ensures that all CodeGroups within a Mintlify documentation page remain synchronized.
      * Selecting a language or code sample in one CodeGroup updates all other CodeGroups on the page
      * to use the CodeBlock at the same index. 
+     * 
+     * TODO: Figure out how to import this component. Currently this entire implementation be copied in directly, 
+     * and then used with <SyncCodeGroups/>.
      *
-     * Just including this component anywhere in your `.mdx` file (e.g., `<SyncCodeGroups />`) 
+     * Just including this component anywhere in your `.mdx` file (e.g., `<SyncCodeGroups/>`) 
      * enables synchronization across all CodeGroups on the page.
      * 
      * **How it works:**


### PR DESCRIPTION
This works to have all code blocks sync up on the page. 

I'm following up with Mintlify to figure out how to import this instead of having to copy + paste so much extra code to get this feature on specific pages.