### PR TITLE
DOCS: python example for "Running Experiments with Prompt Templates" does not run

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -59,8 +59,8 @@
                   "sdk-api/python/logging/galileo-logger"
                 ]
               },
-              "sdk-api/python/experiments",
               "sdk-api/python/datasets",
+              "sdk-api/python/experiments",              
               "sdk-api/python/prompts",
               "sdk-api/python/reference"
             ]
@@ -87,8 +87,8 @@
                   "sdk-api/typescript/logging/galileo-logger"
                 ]
               },
-              "sdk-api/typescript/experiments",
               "sdk-api/typescript/datasets",
+              "sdk-api/typescript/experiments",              
               "sdk-api/typescript/prompts",
               "sdk-api/typescript/reference"
             ]

--- a/getting-started/experiments/running-experiments.mdx
+++ b/getting-started/experiments/running-experiments.mdx
@@ -18,7 +18,7 @@ As you progress from initial testing to systematic evaluation, you'll want to ru
 
 ## Working with Prompts
 
-The simplest way to get started with experimentation is by evaluating prompts directly against datasets. This is especially valuable during the initial prompt development and refinement phase, where you want to test different prompt variations:
+The simplest way to get started with experimentation is by evaluating prompts directly against datasets. This is especially valuable during the initial prompt development and refinement phase, where you want to test different prompt variations. Assuming you've previously created a dataset, you can use the following code to run an experiment:
 
 <CodeGroup>
   <SnippetExperimentsPromptPython />

--- a/sdk-api/python/experiments.mdx
+++ b/sdk-api/python/experiments.mdx
@@ -11,6 +11,10 @@ import SnippetExperimentsCustomMetrics from '/snippets/code/python/experiments/c
 
 Experiments in Galileo allow you to evaluate and compare different prompts, models, and configurations using datasets. This helps you identify the best approach for your specific use case.
 
+<Note>
+  The examples below assume you have a [dataset created](./datasets) first.
+</Note>
+
 ## Running Experiments with Prompt Templates
 
 The simplest way to get started is by using prompt templates:

--- a/sdk-api/typescript/experiments.mdx
+++ b/sdk-api/typescript/experiments.mdx
@@ -12,6 +12,10 @@ import SnippetApiReferenceCreatePrompt from '/snippets/code/typescript/sdk/exper
 
 Galileo Experiments allow you to evaluate and improve your LLM applications by running tests against datasets and measuring performance using various metrics.
 
+<Note>
+  The examples below assume you have a [dataset created](./datasets) first.
+</Note>
+
 ## Running an Experiment with a Prompt Template
 
 The simplest way to get started is by using a prompt template:

--- a/snippets/code/python/experiments/prompt.mdx
+++ b/snippets/code/python/experiments/prompt.mdx
@@ -4,27 +4,31 @@ from galileo.experiments import run_experiment
 from galileo.datasets import get_dataset
 from galileo.resources.models import MessageRole, Message
 
-prompt_template = create_prompt_template(
-	name="storyteller-prompt",
-	project="my-project",
-	messages=[
-		Message(role=MessageRole.SYSTEM, content="You are a great storyteller."),
-		Message(role=MessageRole.USER, content="Write a story about {{topic}}")
-	]
-)
+project = "my-project"
 
+prompt_template = get_prompt_template(name="geography-prompt", project=project)
+# If the prompt template doesn't exist, create it
+if prompt_template is None:
+    prompt_template = create_prompt_template(
+        name="geography-prompt",
+        project=project,
+        messages=[
+            Message(role=MessageRole.SYSTEM, content="You are a geography expert. Respond with only the continent name."),
+            Message(role=MessageRole.USER, content="{{input}}")
+        ]
+    )
 
 results = run_experiment(
-	"story-experiment",
-	dataset=get_dataset(name="storyteller-dataset"),
+	"geography-experiment",
+	dataset=get_dataset(name="countries"),
 	prompt_template=prompt_template,
 	# Optional
 	prompt_settings={
-		max_tokens=256,
-		model_alias="GPT-4o", # Make sure you have an integration set up for the model alias you're using
-		temperature=0.8
+		"max_tokens": 256,
+		"model_alias": "GPT-4o", # Make sure you have an integration set up for the model alias you're using
+		"temperature": 0.8
 	},
 	metrics=["correctness"],
-	project="my-project"
+	project=project
 )
 ```

--- a/snippets/code/typescript/experiments/prompt.mdx
+++ b/snippets/code/typescript/experiments/prompt.mdx
@@ -3,29 +3,33 @@ import { createDataset, createPromptTemplate, runExperiment } from "galileo";
 import { MessageRole } from "galileo/dist/types/message.types";
 
 async function runPromptTemplateExperiment() {
-  const suffix = Array.from({ length: 6 }, () =>
-    Math.floor(Math.random() * 10)
-  ).join("");
-  const projectName = "My first project";
-  const dataset = await createDataset(
-    [{ input: "Cryptography" }, { input: "Middle earth" }],
-    "storyteller-dataset-" + suffix
-  );
+  const projectName = "my-project";
+  
+  const dataset = await createDataset([
+    { input: "Which continent is Spain in?", output: "Europe" },
+    { input: "Which continent is Japan in?", output: "Asia" }
+  ], "geography-dataset");
+
   const template = await createPromptTemplate({
     template: [
-      { role: MessageRole.system, content: "You are a great storyteller." },
-      { role: MessageRole.user, content: "Write a story about {input}" },
+      { role: MessageRole.system, content: "You are a geography expert. Respond with only the continent name." },
+      { role: MessageRole.user, content: "{{input}}" }
     ],
     projectName: projectName,
-    name: "storyteller-prompt-" + suffix,
+    name: "geography-prompt"
   });
 
   await runExperiment({
-    name: "story-experiment",
+    name: "geography-experiment",
     dataset: dataset,
     promptTemplate: template,
+    promptSettings: {
+      max_tokens: 256,
+      model_alias: "GPT-4o",
+      temperature: 0.8
+    },
     metrics: ["correctness"],
-    projectName: projectName,
+    projectName: projectName
   });
 }
 

--- a/snippets/code/typescript/sdk/experiments/custom-dataset.mdx
+++ b/snippets/code/typescript/sdk/experiments/custom-dataset.mdx
@@ -18,7 +18,7 @@ async function runCustomDatasetExperiment() {
         },
       ],
     });
-    return result;
+    return [result.choices[0].message.content];;
   };
 
   await runExperiment({

--- a/snippets/code/typescript/sdk/experiments/prompt-template.mdx
+++ b/snippets/code/typescript/sdk/experiments/prompt-template.mdx
@@ -1,22 +1,30 @@
 ```typescript TypeScript
-import { createPromptTemplate, runExperiment } from "galileo";
+import { createDataset, createPromptTemplate, runExperiment, getDataset } from "galileo";
+import { MessageRole } from "galileo/dist/types/message.types";
 
 async function runPromptTemplateExperiment() {
+  const projectName = "my-project";
+
   const template = await createPromptTemplate({
     template: [
-      { role: "system", content: "You are a great storyteller." },
-      { role: "user", content: "Write a story about {{topic}}" },
+      { role: MessageRole.system, content: "You are a geography expert. Respond with only the continent name." },
+      { role: MessageRole.user, content: "{{input}}" }
     ],
-    projectName: "my-project",
-    name: "storyteller-prompt",
+    projectName: projectName,
+    name: "geography-prompt"
   });
 
   await runExperiment({
-    name: "story-experiment",
-    datasetName: "storyteller-dataset",
+    name: "geography-experiment",
+    datasetName: "geography-dataset", // Make sure you have a dataset created first
     promptTemplate: template,
+    promptSettings: {
+      max_tokens: 256,
+      model_alias: "GPT-4o",
+      temperature: 0.8
+    },
     metrics: ["correctness"],
-    projectName: "my-project",
+    projectName: projectName
   });
 }
 

--- a/snippets/code/typescript/sdk/experiments/runner-function.mdx
+++ b/snippets/code/typescript/sdk/experiments/runner-function.mdx
@@ -13,13 +13,13 @@ async function runFunctionExperiment() {
         { role: "user", content: `Write a story about ${input["topic"]}` },
       ],
     });
-    return result;
+    return [result.choices[0].message.content];;
   };
 
   await runExperiment({
     name: "story-function-experiment",
     datasetName: "storyteller-dataset",
-    runner: runner,
+    function: runner,
     metrics: ["correctness"],
     projectName: "my-project",
   });


### PR DESCRIPTION
Fixes #55

Update experiment documentation and examples to reflect new dataset and prompt template structures


