### PR TITLE
doc: Update to import Message and MessageRole from galileo package

### DIFF
--- a/snippets/code/python/experiments/prompt.mdx
+++ b/snippets/code/python/experiments/prompt.mdx
@@ -1,8 +1,8 @@
 ```python Python
+from galileo import Message, MessageRole
 from galileo.prompts import get_prompt_template, create_prompt_template
 from galileo.experiments import run_experiment
 from galileo.datasets import get_dataset
-from galileo.resources.models import MessageRole, Message
 
 project = "my-project"
 
@@ -13,8 +13,8 @@ if prompt_template is None:
         name="geography-prompt",
         project=project,
         messages=[
-            Message(role=MessageRole.SYSTEM, content="You are a geography expert. Respond with only the continent name."),
-            Message(role=MessageRole.USER, content="{{input}}")
+            Message(role=MessageRole.system, content="You are a geography expert. Respond with only the continent name."),
+            Message(role=MessageRole.user, content="{{input}}")
         ]
     )
 

--- a/snippets/code/python/sdk/prompts/create.mdx
+++ b/snippets/code/python/sdk/prompts/create.mdx
@@ -1,14 +1,14 @@
 ```python Python
+from galileo import Message, MessageRole
 from galileo.prompts import create_prompt_template
-from galileo_core.schemas.logging.llm import Message, MessageRole
 
 # Create a prompt template with system and user messages
 prompt_template = create_prompt_template(
     name="storyteller-prompt",
     project="my-project",
     messages=[
-        Message(role=MessageRole.SYSTEM, content="You are a great storyteller."),
-        Message(role=MessageRole.USER, content="Please write a short story about the following topic: {{topic}}")
+        Message(role=MessageRole.system, content="You are a great storyteller."),
+        Message(role=MessageRole.user, content="Please write a short story about the following topic: {{topic}}")
     ]
 )
 ```

--- a/snippets/code/python/sdk/prompts/prompts-basic.mdx
+++ b/snippets/code/python/sdk/prompts/prompts-basic.mdx
@@ -1,14 +1,14 @@
 ```python Python
+from galileo import Message, MessageRole
 from galileo.prompts import create_prompt_template, get_prompt_template
-from galileo_core.schemas.logging.llm import Message, MessageRole
 
 # Create a prompt template
 prompt = create_prompt_template(
     name="my-prompt",
     project="my-project",
     messages=[
-        Message(role=MessageRole.SYSTEM, content="You are a helpful assistant."),
-        Message(role=MessageRole.USER, content="Answer this question: {{question}}")
+        Message(role=MessageRole.system, content="You are a helpful assistant."),
+        Message(role=MessageRole.user, content="Answer this question: {{question}}")
     ]
 )
 


### PR DESCRIPTION
### Summary

We ensured the right `Message` and `MessageRole` models can be imported directly from `galileo` package in this [update](https://github.com/rungalileo/galileo-python/pull/99) to the SDK. This PR updates the documentation to ensure we import from the right place.