### PR TITLE
Adding links to Python + Typescript SDK within docs

### DIFF
--- a/sdk-api/python/overview.mdx
+++ b/sdk-api/python/overview.mdx
@@ -10,7 +10,7 @@ import SnippetSdkGalileoLogger from '/snippets/code/python/sdk/manual/galileo-lo
 import SnippetSdkContextBasic from '/snippets/code/python/sdk/context/basic.mdx';
 import SnippetSdkContextExplicitFlush from '/snippets/code/python/sdk/context/explicit-flush.mdx';
 
-The Python SDK allows you to log all prompts, responses, and statistics around your LLM usage. There are three main ways to log your application:
+The [Galileo Python SDK](https://github.com/rungalileo/galileo-python/tree/main) ([latest release](https://github.com/rungalileo/galileo-python/releases/latest)) allows you to log all prompts, responses, and statistics around your LLM usage. There are three main ways to log your application:
 
 1. **[Using a wrapper (Recommended)](#wrapper-method)** - Instead of importing common LLMs like `openai`, use Galileo's wrapper which automatically logs everything, no other code changes required!
 2. **[Using a decorator](#decorator-method)** - By decorating a function that calls an LLM with the `@log` decorator, the Galileo SDK logs all AI prompts within.

--- a/sdk-api/python/reference.mdx
+++ b/sdk-api/python/reference.mdx
@@ -16,7 +16,7 @@ import SnippetLangchainBasic from '/snippets/code/python/sdk/wrappers/langchain.
 
 ## Introduction
 
-This document provides a comprehensive reference for the Galileo Python SDK, covering all the key classes, methods, and functions available for logging and analyzing your LLM applications.
+This document provides a comprehensive reference for the [Galileo Python SDK](https://github.com/rungalileo/galileo-python/tree/main) ([latest release](https://github.com/rungalileo/galileo-python/releases/latest)), covering all the key classes, methods, and functions available for logging and analyzing your LLM applications.
 
 ## Installation
 

--- a/sdk-api/typescript/overview.mdx
+++ b/sdk-api/typescript/overview.mdx
@@ -8,7 +8,7 @@ import SnippetInstallationPnpm from '/snippets/code/typescript/sdk/installation/
 import SnippetEnvSetup from '/snippets/code/typescript/sdk/env-setup/env.mdx'
 import SnippetOpenAIBasic from '/snippets/code/typescript/sdk/wrappers/openai-basic.mdx'
 
-The Galileo TypeScript SDK provides a comprehensive set of tools for logging, evaluating, and experimenting with LLM applications. It's designed to be easy to use while providing powerful features for monitoring and improving your AI applications.
+The [Galileo TypeScript SDK](https://github.com/rungalileo/galileo-js) ([latest release](https://github.com/rungalileo/galileo-js/releases/latest)) provides a comprehensive set of tools for logging, evaluating, and experimenting with LLM applications. It's designed to be easy to use while providing powerful features for monitoring and improving your AI applications.
 
 ## Logging Methods
 

--- a/sdk-api/typescript/reference.mdx
+++ b/sdk-api/typescript/reference.mdx
@@ -18,7 +18,7 @@ import SnippetCustomDataset from '/snippets/code/typescript/sdk/experiments/cust
 
 ## Introduction
 
-This document covers the design and developer experience of the TypeScript client library for Galileo.
+This document covers the design and developer experience of the TypeScript client library for Galileo. Here is the full [Galileo TypeScript SDK ](https://github.com/rungalileo/galileo-js) ([latest release](https://github.com/rungalileo/galileo-js/releases/latest)).
 
 > Note: This library is in pre-release mode and may not be stable.
 


### PR DESCRIPTION
Added links to Python + TS SDKs (and latest release link) in docs subsections (references/overview for both Python + TS) per [Erin's issue here ](https://github.com/orgs/rungalileo/projects/8/views/1?pane=issue&itemId=106153508&issue=rungalileo%7Cdocs-official%7C83)