### PR TITLE
Converting tool span inputs/outputs to strings

### DIFF
--- a/sdk-api/python/logging/galileo-logger.mdx
+++ b/sdk-api/python/logging/galileo-logger.mdx
@@ -123,8 +123,8 @@ logger.add_retriever_span(
 
 ```python
 logger.add_tool_span(
-    input={"operation": "add", "numbers": [1, 2, 3]},
-    output={"result": 6},
+    input=json.dumps({"operation": "add", "numbers": [1, 2, 3]}),
+    output=json.dumps({"result": 6}),
     name="Calculator",  # Optional
     duration_ns=100000,  # Optional
     metadata={"tool_version": "1.0"},  # Optional


### PR DESCRIPTION
The tool span example has JSON objects for the `input` and `output`, but this expects strings. Fixes #113.