### PR TITLE
feat: Point v2 APIs to the 2.0 cluster and not acme

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -222,7 +222,7 @@
       {
         "group": "API Reference",
         "openapi": {
-          "source": "https://api.acme.rungalileo.io/public/openapi.json"
+          "source": "https://api.galileo.ai/public/openapi.json"
         }
       },
       {


### PR DESCRIPTION
## Describe your changes

Changed the V2 API documentation to point to `api.galileo.ai` instead of `api.acme.galileo.ai`

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have reviewed any spelling mistakes highlighted by the checks
- [x] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [ ] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
