### PR TITLE
SC-31279: adds note about GALILEO_CONSOLE_URL variable to typescript, python SDK overview

### DIFF
--- a/sdk-api/python/overview.mdx
+++ b/sdk-api/python/overview.mdx
@@ -12,13 +12,7 @@ import SnippetSdkContextBasic from "/snippets/code/python/sdk/context/basic.mdx"
 import SnippetSdkContextExplicitFlush from "/snippets/code/python/sdk/context/explicit-flush.mdx";
 import { InfoNote } from "/snippets/components/info-note.mdx";
 
-The [Galileo Python SDK](https://github.com/rungalileo/galileo-python/) ([latest release](https://github.com/rungalileo/galileo-python/releases/latest)) allows you to log all prompts, responses, and statistics around your LLM usage. There are three main ways to log your application:
-
-1. **[Using a wrapper (Recommended)](#wrapper-method)** - Instead of importing common LLMs like `openai`, use Galileo's wrapper which automatically logs everything, no other code changes required!
-2. **[Using a decorator](#decorator-method)** - By decorating a function that calls an LLM with the `@log` decorator, the Galileo SDK logs all AI prompts within.
-3. **[Directly using the `GalileoLogger` class (Manual)](#manual-method)** - As a last resort, you can directly use the base class, but this requires calling multiple methods per LLM call.
-
-Regardless of how you go about logging your AI application, you will still need to initialize your API keys and install the Galileo SDK by following the steps below.
+The [Galileo Python SDK](https://github.com/rungalileo/galileo-python/) ([latest release](https://github.com/rungalileo/galileo-python/releases/latest)) provides a comprehensive set of tools for logging, evaluating, and experimenting with LLM applications. Regardless of how you go about logging your AI application, you will still need to install the Galileo SDK and initialize your API keys by following the steps below.
 
 <InfoNote>Visit the [Galileo PyPI package page](https://pypi.org/project/galileo/) for more installation options and version information.</InfoNote>
 
@@ -30,22 +24,35 @@ Install Galileo's Python SDK to your project by running:
 pip install galileo
 ```
 
-## Initialization/Authentication
+## Initialization and Authentication
 
 Create or update a `.env` file with the following values:
 
-```env
+```env ENV
 # Scoped to an Organization
 GALILEO_API_KEY=...
 
-# Optional, set a default Project
+# (Optional) set a default Project
 GALILEO_PROJECT=...
-# Optional, set a default Log Stream
+
+# (Optional) set a default Log Stream
 GALILEO_LOG_STREAM=...
+
+# (Optional) set a path to your custom Galileo console deployment
+GALILEO_CONSOLE_URL=...
 ```
+
+<Note>The SDK automatically targets the [production console](https://app.galileo.ai). If you are using a deployment of Galileo on premises or in the cloud, point `GALILEO_CONSOLE_URL` to your own installation.</Note>
 
 <a id="wrapper-method"></a>
 ## Logging
+
+
+The Galileo Python SDK allows you to log all prompts, responses, and statistics around your LLM usage. There are three main ways to log your application:
+
+1. **[Using a wrapper (Recommended)](#wrapper-method)** - Instead of importing common LLMs like `openai`, use Galileo's wrapper which automatically logs everything, no other code changes required!
+2. **[Using a decorator](#decorator-method)** - By decorating a function that calls an LLM with the `@log` decorator, the Galileo SDK logs all AI prompts within.
+3. **[Directly using the `GalileoLogger` class (Manual)](#manual-method)** - As a last resort, you can directly use the base class, but this requires calling multiple methods per LLM call.
 
 ### Using LLM Wrappers
 
@@ -86,8 +93,8 @@ Here's how to create a tool span using the decorator:
 For more detailed information and examples, see the [@log Decorator documentation](./logging/log-decorator).
 
 <a id="manual-method"></a>
-### Pure invocation using the `GalileoLogger` This is the most verbose way to log your application. It requires manually calling the `GalileoLogger` class and adding spans to the trace. We recommend using the other two methods whenever
-possible.
+### Pure invocation using the `GalileoLogger` 
+This is the most verbose way to log your application. It requires manually calling the `GalileoLogger` class and adding spans to the trace. We recommend using the other two methods whenever possible.
 
 <CodeGroup>
   <SnippetSdkGalileoLogger />

--- a/sdk-api/typescript/overview.mdx
+++ b/sdk-api/typescript/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: An overview of the Galileo TypeScript SDK.
 ---
 
 import SnippetInstallationNpm from "/snippets/code/typescript/sdk/installation/npm.mdx";
@@ -13,15 +14,12 @@ The [Galileo TypeScript SDK](https://github.com/rungalileo/galileo-js) ([latest 
 
 <InfoNote>Visit the [Galileo NPM package page](https://www.npmjs.com/package/galileo) for more installation options and version information.</InfoNote>
 
-## Logging Methods
+## Key Features
 
-The TypeScript SDK allows you to log all prompts, responses, and statistics around your LLM usage. There are three main ways to log your application:
-
-1. **[Using a wrapper (Recommended)](/sdk-api/typescript/wrappers/wrappers-overview)** - Instead of importing LLM clients directly like `openai`, use Galileo's wrapper which automatically logs everything with no other code changes required!
-2. **[Using the log function wrapper](/sdk-api/typescript/logging/log-function-wrapper)** - By wrapping a function that calls an LLM with the `log` function wrapper, you can create workflow spans with nested LLM calls and tool spans.
-3. **[Directly using the GalileoLogger class (Manual)](/sdk-api/typescript/logging/galileo-logger)** - For more advanced use cases, you can use the GalileoLogger directly to have full control over the logging process.
-
-Regardless of which logging method you choose, you will need to initialize your API keys and install the Galileo SDK by following the steps below.
+- **Logging**: Capture LLM interactions, tool usage, and workflow execution
+- **Experimentation**: Run experiments to evaluate and improve your LLM applications
+- **Datasets**: Create and manage datasets for testing and evaluation
+- **Prompts**: Create, version, and test prompt templates
 
 ## Installation
 
@@ -31,12 +29,15 @@ Regardless of which logging method you choose, you will need to initialize your 
   <SnippetInstallationPnpm />
 </CodeGroup>
 
-## Key Features
+## Initialization and Authentication
 
-- **Logging**: Capture LLM interactions, tool usage, and workflow execution
-- **Experimentation**: Run experiments to evaluate and improve your LLM applications
-- **Datasets**: Create and manage datasets for testing and evaluation
-- **Prompts**: Create, version, and test prompt templates
+Make sure you have a Galileo API key and configure Galileo using environment variables:
+
+<CodeGroup>
+  <SnippetEnvSetup />
+</CodeGroup>
+
+<Note>The SDK automatically targets the [production console](https://app.galileo.ai). If you are using a deployment of Galileo on premises or in the cloud, point `GALILEO_CONSOLE_URL` to your own installation.</Note>
 
 ## Getting Started
 
@@ -46,22 +47,23 @@ The simplest way to get started is to use our OpenAI client wrapper:
   <SnippetOpenAIBasic />
 </CodeGroup>
 
-## Authentication
+## Logging Methods
 
-Make sure you have a Galileo API key and configure Galileo using environment variables:
+The TypeScript SDK allows you to log all prompts, responses, and statistics around your LLM usage. There are three main ways to log your application:
 
-<CodeGroup>
-  <SnippetEnvSetup />
-</CodeGroup>
+1. **[Using a wrapper (Recommended)](/sdk-api/typescript/wrappers/wrappers-overview)** - Instead of importing LLM clients directly like `openai`, use Galileo's wrapper which automatically logs everything with no other code changes required!
+2. **[Using the log function wrapper](/sdk-api/typescript/logging/log-function-wrapper)** - By wrapping a function that calls an LLM with the `log` function wrapper, you can create workflow spans with nested LLM calls and tool spans.
+3. **[Directly using the `GalileoLogger` class (Manual)](/sdk-api/typescript/logging/galileo-logger)** - For more advanced use cases, you can use the GalileoLogger directly to have full control over the logging process.
 
-## SDK Components
+Regardless of which logging method you choose, you will need to initialize your API keys and install the Galileo SDK by following the steps below.
 
-The Galileo TypeScript SDK consists of several components:
+## Additional Documentation
 
-- **Wrappers**: Easily integrate with popular LLM providers like OpenAI
-- **Core Logging**: Log LLM interactions, tool usage, and workflow execution
-- **Experiments**: Run experiments to evaluate and improve your LLM applications
-- **Datasets**: Create and manage datasets for testing and evaluation
-- **Prompts**: Create, version, and test prompt templates
+The Galileo TypeScript SDK consists of several components: Check out the individual component documentation for more details.
 
-Check out the individual component documentation for more details.
+- [**Wrappers**](/sdk-api/typescript/wrappers/wrappers-overview): Easily integrate with popular LLM providers like OpenAI
+- [**Core Logging**](/sdk-api/typescript/logging/galileo-logger): Log LLM interactions, tool usage, and workflow execution
+- [**Experiments**](/sdk-api/typescript/experiments): Run experiments to evaluate and improve your LLM applications
+- [**Datasets**](/sdk-api/typescript/datasets): Create and manage datasets for testing and evaluation
+- [**Prompts**](/sdk-api/typescript/prompts): Create, version, and test prompt templates
+

--- a/snippets/code/typescript/sdk/env-setup/env.mdx
+++ b/snippets/code/typescript/sdk/env-setup/env.mdx
@@ -2,9 +2,12 @@
 # Scoped to an Organization
 GALILEO_API_KEY=...
 
-# Optional, set a default Project
+# (Optional) set a default Project
 GALILEO_PROJECT=...
 
-# Optional, set a default Log Stream
+# (Optional) set a default Log Stream
 GALILEO_LOG_STREAM=...
+
+# (Optional) set a path to your custom Galileo console deployment
+GALILEO_CONSOLE_URL=...
 ```


### PR DESCRIPTION
## Describe your changes

* Adds optional `GALILEO_CONSOLE_URL` to typescript, python .env file snippets 
* Adds note below env snippet to suggest when the optional variable might be required
* Fixes incorrectly formatted heading in Python SDK overview (pictures attached in comments)
* Synchronizes python and typescript overview layout
  * Rearranges typescript sections to match dev flow (`package install → environment variables → code samples`)

## Shortcut ticket

[SC-31279](https://app.shortcut.com/galileo/story/31279/add-docs-on-galileo-console-url)

## Checklist before requesting a review

- [ ] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have reviewed any spelling mistakes highlighted by the checks
- [x] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
