### PR TITLE
SC-31236: update prompt-template experiment docs

### DIFF
--- a/sdk-api/python/experiments.mdx
+++ b/sdk-api/python/experiments.mdx
@@ -12,9 +12,12 @@ import SnippetExperimentsCustomMetrics from "/snippets/code/python/concepts/expe
 Experiments in Galileo allow you to evaluate and compare different prompts, models, and configurations using datasets. This helps you identify the best approach for your specific use case.
 
 
-## Running Experiments with Prompt Templates
+## Running an Experiment with a Prompt Template
 
-The simplest way to get started is by using a prompt template. The `get_dataset` function below expects a dataset that you created through either the [console](https://app.galileo.ai/datasets) or the [SDK](./datasets#creating-datasets). Ensure you have saved a dataset before running the experiment!
+The simplest way to get started is by using a prompt template. 
+
+* If you have an existing prompt template, you can fetch it by importing and using the [`get_prompt_template`](/sdk-api/python/prompts#getting-prompt-templates) function from `galileo.prompts`.
+* The `get_dataset` function below expects a dataset that you created through either the [console](https://app.galileo.ai/datasets) or the [SDK](/sdk-api/python/datasets#creating-datasets). Ensure you have saved a dataset before running the experiment!
 
 <CodeGroup>
   <SnippetExperimentsPrompt />
@@ -22,7 +25,7 @@ The simplest way to get started is by using a prompt template. The `get_dataset`
 
 ## Running Experiments with Custom Functions
 
-For more complex scenarios, you can use custom functions with the OpenAI wrapper. Here, you may use either a [saved dataset](./datasets#creating-datasets) or a [custom one](#custom-dataset-evaluation)
+For more complex scenarios, you can use custom functions with the OpenAI wrapper. Here, you may use either a [saved dataset](/sdk-api/python/datasets#creating-datasets) or a [custom one](#custom-dataset-evaluation)
 
 <CodeGroup>
   <SnippetExperimentsExistingDataset />

--- a/sdk-api/typescript/experiments.mdx
+++ b/sdk-api/typescript/experiments.mdx
@@ -16,7 +16,10 @@ Galileo Experiments allow you to evaluate and improve your LLM applications by r
 
 ## Running an Experiment with a Prompt Template
 
-The simplest way to get started is by using a prompt template. In the `runExperiment` options below, `datasetName` expects a dataset that you created through either the [console](https://app.galileo.ai/datasets) or the [SDK](./datasets#creating-and-using-datasets). Ensure you have saved a dataset before running the experiment!
+The simplest way to get started is by using a prompt template. 
+
+* If you have an existing prompt template, you can fetch it by importing and using the [`getPromptTemplate`](/sdk-api/typescript/prompts#retrieving-a-prompt-template) function from the `galileo` SDK.
+* In the `runExperiment` options below, `datasetName` expects a dataset that you created through either the [console](https://app.galileo.ai/datasets) or the [SDK](./datasets#creating-and-using-datasets). Ensure you have saved a dataset before running the experiment!
 
 <CodeGroup>
   <SnippetPromptTemplate />

--- a/snippets/code/python/concepts/experiments/prompt.mdx
+++ b/snippets/code/python/concepts/experiments/prompt.mdx
@@ -1,23 +1,25 @@
 ```python Python
 from galileo import Message, MessageRole
-from galileo.prompts import get_prompt_template, create_prompt_template
+from galileo.prompts import create_prompt_template 
 from galileo.experiments import run_experiment
 from galileo.datasets import get_dataset
 
 project = "my-project"
 
-prompt_template = get_prompt_template(name="geography-prompt", project=project)
-# If the prompt template doesn't exist, create it
-if prompt_template is None:
-    prompt_template = create_prompt_template(
-        name="geography-prompt",
-        project=project,
-        messages=[
-            Message(role=MessageRole.system, content="You are a geography expert. Respond with only the continent name."),
-            Message(role=MessageRole.user, content=f"{input['input']}")
-        ]
-    )
+# 1a. If the prompt template does not exist, create it:
+prompt_template = create_prompt_template(
+	name="geography-prompt",
+	project=project,
+	messages=[
+		Message(role=MessageRole.system, content="You are a geography expert. Respond with only the continent name."),
+		Message(role=MessageRole.user, content=f"{input['input']}")
+	]
+)
 
+# 1b. (OPTIONAL) If the prompt template already exists, fetch it:
+# prompt_template = get_prompt_template(name="geography-prompt", project=project)  
+
+# 2. Run the experiment and get results
 results = run_experiment(
 	"geography-experiment",
 	dataset=get_dataset(name="countries"), # Name of a dataset you created

--- a/snippets/code/typescript/sdk/experiments/prompt-template.mdx
+++ b/snippets/code/typescript/sdk/experiments/prompt-template.mdx
@@ -1,19 +1,24 @@
 ```typescript TypeScript
-import { createDataset, createPromptTemplate, runExperiment, getDataset } from "galileo";
-import { MessageRole } from "galileo/dist/types/message.types";
+import { createPromptTemplate, runExperiment } from "galileo";
+import { MessageRole } from "galileo/types";
 
 async function runPromptTemplateExperiment() {
   const projectName = "my-project";
 
+  // 1a. If the prompt template does not exist, create it:
   const template = await createPromptTemplate({
+    name: "geography-prompt",
+    projectName: projectName,
     template: [
       { role: MessageRole.system, content: "You are a geography expert. Respond with only the continent name." },
-      { role: MessageRole.user, content: "{{input}}" },
-    ],
-    projectName: projectName,
-    name: "geography-prompt",
+      { role: MessageRole.user, content: "{{input}}" }
+    ]
   });
 
+  // 1b. (OPTIONAL) If the prompt template already exists, fetch it:
+  // const template = await getPromptTemplate({ name: "geography-prompt", projectName })
+
+  // 2. Run the experiment with your prompt template
   await runExperiment({
     name: "geography-experiment",
     datasetName: "geography-dataset", // Make sure you have a dataset created first
@@ -21,13 +26,14 @@ async function runPromptTemplateExperiment() {
     promptSettings: {
       max_tokens: 256,
       model_alias: "GPT-4o",
-      temperature: 0.8,
+      temperature: 0.8
     },
     metrics: ["correctness"],
-    projectName: projectName,
+    projectName: projectName
   });
 }
 
 // Run the experiment
 runPromptTemplateExperiment();
+
 ```


### PR DESCRIPTION
## Describe your changes

* updates python, typescript documentation for prompt template experiments
* updates python, typescript snippets to focus on creating prompt templates
* unified section headings for parity between python and typescript docs

## Shortcut ticket

[SC-31236](https://app.shortcut.com/galileo/story/31236/docs-fix-python-experiment-snippet)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have reviewed any spelling mistakes highlighted by the checks
- [x] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
