### PR TITLE
fix: Have v2 docs point to v2 spec

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -235,7 +235,7 @@
       {
         "group": "API Reference",
         "openapi": {
-          "source": "https://api.galileo.ai/public/openapi.json"
+          "source": "https://api.galileo.ai/public/v2/openapi.json"
         }
       },
       {


### PR DESCRIPTION
## Describe your changes

Updates the v2 documentation to use v2_openapi_spec which list only v2 APIs.

## Shortcut ticket

[sc-31461](https://app.shortcut.com/galileo/story/31461/separate-public-docs-for-v1-and-v2)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [ ] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have reviewed any spelling mistakes highlighted by the checks
- [ ] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
