### PR TITLE
Regrouping cookbooks

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -123,11 +123,16 @@
         "group": "Cookbooks",
         "pages": [
           {
-            "group": "Use Cases",
+            "group": "Agents",
             "pages": [
               "cookbooks/use-cases/agent-weather-vibes-app",
               "cookbooks/use-cases/agent-langchain",
-              "cookbooks/use-cases/multi-agent-langgraph/multi-agent-langgraph",
+              "cookbooks/use-cases/multi-agent-langgraph/multi-agent-langgraph"
+            ]
+          },
+          {
+            "group": "RAG",
+            "pages": [
               "cookbooks/use-cases/rag-mongodb-langchain-integration"
             ]
           }


### PR DESCRIPTION
## Describe your changes

All cookbooks were under a sub group called use cases. This added an unnecessary and confusing step to the navigation.

This change re-groups the cookbooks as agents and rag. Nothing is moved, so no need for redirects.

## Shortcut ticket

None - small tweak

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have reviewed any spelling mistakes highlighted by the checks
- [x] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
