### PR TITLE
SC-32264: GalileoContext vs GalileoLogger vs Log Decorator

### DIFF
--- a/concepts/logging/compare-logging-methods.mdx
+++ b/concepts/logging/compare-logging-methods.mdx
@@ -1,0 +1,139 @@
+---
+title: GalileoContext vs GalileoLogger vs @log Decorator
+sidebarTitle: Logging Methods
+description: Understand the difference between Galileo's SDK logging tools
+---
+
+import SnippetPythonGalileoLogger from "/snippets/code/python/concepts/logging/traces/galileo-logger.mdx";
+import SnippetTSGalileoLogger from "/snippets/code/typescript/concepts/logging/traces/galileo-logger.mdx";
+import LogDecoratorPy from "/snippets/code/python/sdk/decorators/log-decorator-span-types.mdx"
+import LogDecoratorTs from "/snippets/code/typescript/sdk/logging/log-wrapper-span-types.mdx"
+
+## Introduction
+
+When building a Generative AI application, understanding its behavior—what data is processed, where errors occur, and how long responses take—is crucial. Galileo provides three primary ways to log data from your AI applications:
+
+- `galileo_context` for simple, session-based logging
+- `GalileoLogger` class for flexible control
+- `@log` decorator for granular, function-level logging
+
+Each method is best suited for specific scenarios. This guide compares these approaches and offers guidance on when to use each one. If you're in a hurry, you can jump right to the [summary here](#when-to-use-each-method).
+
+
+## `galileo_context`
+
+The `galileo_context` context manager provides an easy way to control logging for a block of code. It is only available in the [Python SDK](/sdk-api/python/logging/galileo-context), and allows you to start logging quickly while handling details like creating traces or saving events to the Galileo Console for you. 
+
+### Example
+
+In the illustration below, all events captured within the `with` scope are bundled into a single [logging session](/concepts/logging/sessions/sessions-overview), and the data is sent to Galileo Console when the scope is done executing. You can see more detailed examples [here](/sdk-api/python/logging/galileo-context)
+
+```python Python
+from galileo import galileo_context
+
+# You can specify a different project name and/or log stream for the events.
+with galileo_context(project="my-project", log_stream="chat-stream"):
+    
+    # For simplicity, assume "llm_call" is defined elsewhere.
+    result = llm_call()  
+```
+
+It can also be used to access a managed `GalileoLogger` instance:
+
+```python Python
+from galileo import galileo_context
+
+# You can specify a different project name and/or log stream for the events.
+logger = galileo_context.get_logger_instance()
+ 
+# logger.add_trace() ...
+```
+
+### When to use galileo_context
+
+The Galileo Context manager is great when your logic is contained in a single block of code, or you are using the Python SDK and want to quickly get started logging. However, it cannot be used in TypeScript projects.
+
+
+
+## `GalileoLogger`
+
+The `GalileoLogger` class gives you more flexible control over logging, and is available in both the 
+[Python](/sdk-api/python/logging/galileo-logger) and [TypeScript](/sdk-api/typescript/logging/galileo-logger) SDKs. It lets you decide when your logging session starts or ends, and to create spans and traces manually within your logging session. `GalileoLogger` supports various span types (LLM, retriever, tool, workflow, agent), as well as [logging session management](/concepts/logging/sessions/using-sessions#steps).
+
+### Example
+
+The example below shows how to 
+
+1. Create a `GalileoLogger` instance
+1. Manually create a `Trace` for your application events
+1. Add `Spans` to the Trace, and 
+1. Both conclude and flush the logs. 
+
+<CodeGroup>
+  <SnippetPythonGalileoLogger />
+  <SnippetTSGalileoLogger />
+</CodeGroup>
+
+### When to use GalileoLogger
+
+This approach is ideal for complex applications that require fine-grained logging control, or where your app logic is spread around different functions: just create the `logger` instance and pass it around to the parts of your app that will generate (or manually create) traces or spans. 
+
+
+## @log Decorator
+
+The `@log` decorator ([Python](/sdk-api/python/logging/log-decorator), [TypeScript](/sdk-api/typescript/logging/log-function-wrapper)) provides a simple way to log individual functions, capturing their inputs and outputs as spans. It is the most granular approach to capturing events in your application, and can even support generator functions. 
+
+<Note>The `log` function is not an annotation in the TypeScript SDK. See the [documentation](/sdk-api/typescript/logging/log-function-wrapper) for more info.</Note>
+
+### Example
+
+You can decorate any function you want to log, offering flexibility and control. The `@log` decorator also supports different Span types:
+
+<CodeGroup>
+  <LogDecoratorPy />
+  <LogDecoratorTs />
+</CodeGroup>
+
+
+### When to use the Log function
+
+`@log` is great for when you want to define what [Spans](/concepts/logging/spans) you would like to see in your logs (e.g. an LLM response, or a call to a helper function). It works best for functions that represent meaningful work units. Note that, if your application has a lot of units to be manually logged, this approach will require a little more work than the others. 
+
+
+
+## When to Use Each Method
+
+| Method             | Use When...                                                                                                          |
+|:--------------------|:----------------------------------------------------------------------------------------------------------------------|
+| `galileo_context`  | You are using the Python SDK, want to log events with minimal code, and your logic is in a single block              |
+| `GalileoLogger`    | You need more flexible control over your logging session, and/or your application logic depends on more than one file |
+| `@log` decorator   | You want to capture individual function calls within your logging session, and/or combine them into custom workflows |
+
+## Conclusion
+
+Each Galileo logging method helps you capture your application's activity, but the right choice depends on your needs:
+
+- Use `galileo_context` to start logging with minimal effort
+- Use `GalileoLogger` when you need more control over every detail
+- Use `@log` for even more granular control in tracking function calls
+
+You can also combine these methods for even more flexibility.
+
+## Next Steps
+
+Learn more about:
+
+- [Spans](/concepts/logging/spans) — the smallest units that make up your application logs
+- [Traces](/concepts/logging/traces) — how to create and use traces
+- [Sessions](/concepts/logging/sessions/sessions-overview) — logging sessions and how to use them
+
+## Related Resources
+
+- [Galileo Context](/sdk-api/python/logging/galileo-context)
+- `GalileoLogger` class:
+  - [Python SDK](/sdk-api/python/logging/galileo-logger)
+  - [TypeScript SDK](/sdk-api/typescript/logging/galileo-logger)
+- `@log` Decorator:
+  - [Python SDK](/sdk-api/python/logging/log-decorator)
+  - [TypeScript SDK](/sdk-api/typescript/logging/log-function-wrapper)
+

--- a/docs.json
+++ b/docs.json
@@ -178,7 +178,8 @@
                 ]
               },
               "concepts/logging/traces",
-              "concepts/logging/spans"
+              "concepts/logging/spans",
+              "concepts/logging/compare-logging-methods"
             ]
           },
           "concepts/datasets",

--- a/sdk-api/python/logging/log-decorator.mdx
+++ b/sdk-api/python/logging/log-decorator.mdx
@@ -3,6 +3,8 @@ title: "@log Decorator"
 description: "Easily capture function inputs and outputs as spans in your traces"
 ---
 
+import LogDecoratorSpanTypesPy from "/snippets/code/python/sdk/decorators/log-decorator-span-types.mdx"
+
 The `@log` decorator provides a simple way to capture the inputs and outputs of a function as a span within a trace. This is particularly useful for tracking the execution of your AI application without having to manually create and manage spans.
 
 ## Overview
@@ -37,34 +39,7 @@ response = my_function("Some input text")
 
 By default, the `@log` decorator creates a workflow span, but you can specify different span types depending on what your function does:
 
-```python
-from galileo import log
-
-# Create a workflow span (default)
-@log
-def my_workflow_function(input):
-    # This can contain multiple steps and child spans
-    return result
-
-# Create an LLM span
-@log(span_type="llm")
-def my_llm_function(input):
-    # This should be for direct LLM calls
-    return result
-
-# Create a retriever span
-@log(span_type="retriever")
-def my_retriever_function(query):
-    # For functions that retrieve documents
-    # If the output is an array, it will be captured as documents
-    return ["doc1", "doc2"]
-
-# Create a tool span
-@log(span_type="tool")
-def my_tool_function(input="tool call input"):
-    # For functions that act as tools in an agent system
-    return "tool call output"
-```
+<LogDecoratorSpanTypesPy />
 
 ### Span Type Descriptions
 

--- a/snippets/code/python/sdk/decorators/log-decorator-span-types.mdx
+++ b/snippets/code/python/sdk/decorators/log-decorator-span-types.mdx
@@ -1,0 +1,28 @@
+```python Python
+from galileo import log
+
+# Create a workflow span (default)
+@log
+def my_workflow_function(input):
+    # This can contain multiple steps and child spans
+    return result
+
+# Create an LLM span
+@log(span_type="llm")
+def my_llm_function(input):
+    # This should be for direct LLM calls
+    return result
+
+# Create a retriever span
+@log(span_type="retriever")
+def my_retriever_function(query):
+    # For functions that retrieve documents
+    # If the output is an array, it will be captured as documents
+    return ["doc1", "doc2"]
+
+# Create a tool span
+@log(span_type="tool")
+def my_tool_function(input="tool call input"):
+    # For functions that act as tools in an agent system
+    return "tool call output"
+```

--- a/snippets/code/typescript/sdk/logging/log-wrapper-span-types.mdx
+++ b/snippets/code/typescript/sdk/logging/log-wrapper-span-types.mdx
@@ -1,0 +1,33 @@
+```typescript TypeScript
+import { log } from galileo 
+
+/**
+ * `log` returns a wrapped function. When you call the wrapped function,
+ * its inputs and output will be captured in a Span.
+ */
+
+// Create a workflow span (default)
+const myWorkflowFunction = log({ name: "My Workflow" }, (_input: unknown) => {
+    // This can contain multiple steps and child spans
+    return result
+})
+
+// Create an LLM span
+const myLlmFunction = log({spanType: "llm" }, (_input: unknown) => {
+    // This should be for direct LLM calls
+    return result 
+})
+
+// Create a retriever span
+const myRetrieverFunction = log({spanType: "retriever" }, (_query: unknown) => {
+    // For functions that retrieve documents
+    // If the output is an array, it will be captured as documents
+    return ["doc1", "doc2"]
+})
+
+// Create a tool span
+const myToolFunction = log({spanType: "tool" }, (input="tool call input") => {
+    // For functions that act as tools in an agent system
+    return "tool call output"
+})
+```


### PR DESCRIPTION
## Describe your changes

* Adds a new page under `Concepts > Logging` comparing the three logging methods
* Extracts the `@log` decorator python snippet showing Span types to a **snippets** file for use in the new doc
  * Adds typescript equivalent snippet for `log` function wrapper
  * Re-imported python snippet into the extraction source-file
* Adds new page to `docs.json`

## Shortcut ticket

For Galileo internally raised PRs only, please update this with your shortcut ticket.

[SC-32264](https://app.shortcut.com/galileo/story/32264)


## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have reviewed any spelling mistakes highlighted by the checks
- [x] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
