### PR TITLE
Adding missing doc to sidebar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -212,6 +212,7 @@
                 "group": "Wrappers",
                 "pages": [
                   "sdk-api/python/wrappers/wrappers-overview",
+                  "sdk-api/python/wrappers/langchain",
                   "sdk-api/python/wrappers/openai"
                 ]
               },


### PR DESCRIPTION
## Describe your changes

The Python log decorator docs linked to a langchain doc that wasn't in the sidebar. This change adds it to the sidebar.

## Shortcut ticket

None

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - All checks have passed
- [x] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
