### PR TITLE
Removing mentions of experiments from sessions

### DIFF
--- a/concepts/logging/sessions/sessions-overview.mdx
+++ b/concepts/logging/sessions/sessions-overview.mdx
@@ -13,18 +13,17 @@ A Session is **a collection of Traces, Events, and Spans emitted by your Applica
 
 ## Introduction
 
-Imagine you're building a simple LLM-powered customer service chat application. In testing it, you might want to see how a single multi-turn conversation flows from user prompt to tool calling to model response. **Sessions** solve this problem by bundling low-level events into a cohesive unit, so you can trace an entire LLM interaction from start to finish.
-
+Imagine you're building an LLM-powered customer service chat application. During development or in production, you will want to see how a single multi-turn conversation flows from user prompt, to tool calling, to model response. **Sessions** solve this problem by bundling log stream traces into a cohesive unit, so you can observe and evaluate an entire LLM interaction from start to finish.
 
 ## Core Concepts
 
 Let's take a look at the building blocks of a session.
 
 ### Span → Trace → Session
+
 - [**Span**](/concepts/logging/spans): The smallest logging unit the system, typically representing a single operation, function call, or request. Each user message, model API call, or model tool usage generates a *Span*.  
 - [**Trace**](/concepts/logging/traces): When multiple spans occur as part of a single logical operation (e.g. a request that triggers several downstream calls) they form a *Trace*. Traces allow you to see parent/child relationships among spans.  
-- **Session**: A collection of one or more traces that together represent an entire experiment, interaction, or multi-step evaluation. A Session bundles related traces so that you can analyze an entire workflow end to end, even if it spans multiple services, threads, or agents.
-
+- **Session**: A collection of one or more traces that together represent an entire interaction, or multi-step evaluation. A Session bundles related traces so that you can analyze an entire workflow end to end, even if it spans multiple services, threads, or agents.
 
 ## How do Sessions differ from Log Streams?
 
@@ -32,22 +31,15 @@ A [**Log Stream**](/concepts/logging/logstreams) is a continuous sequence of log
 
 On the other hand, a *Session* is a way to group Traces that are logically connected. And with Galileo, every Session is stored in a Log Stream that you can specify either explicitly or using environment variables.
 
-<Note>
-You can use **Sessions** to segment a log stream into coherent experiments or runs, making it easier to analyze end-to-end behavior.
-</Note>
-
-
 ## How do Sessions differ from Workflows?
+
 A **Workflow** is a defined sequence of steps or tasks. It may include branching logic, conditional steps, and dependencies.  
 
-A *Session* can contain one or more *Workflows* if they are part of the same overall experiment or evaluation.
-
+A *Session* can contain one or more *Workflows* if they are part of the same overall evaluation.
 
 ## Where can I find my sessions?
 
 Sessions can be viewed in the [Galileo Console](/concepts/logging/sessions/using-sessions#view-your-session). When you create a session, you will usually select a Log Stream where they will be found. (If you don't specify one, Galileo will use your default log stream). 
-
-You can view them in a few easy steps:
 
 <ViewSessionsInConsole />
 
@@ -56,9 +48,10 @@ You can learn more about creating and using sessions [here](/concepts/logging/se
 ## Conclusion
 
 A Session can collect multiple workflow runs and traces into one cohesive view. By using Sessions in your LLM application, you can:  
+
 1. Organize logs and metrics for each customer interaction or batch evaluation run, so debugging and analysis become straightforward.
-2. Drill down into any step—inspect the span for tokenization latency or the trace for scoring logic—without losing context.  
-3. Easily compare multiple chat sessions to track performance improvements.  
+1. Drill down into any step, inspecting the span for tokenization latency or the trace for scoring logic without losing context.  
+1. Compare multiple chat sessions to track performance improvements.  
 
 ## Next Steps
 

--- a/concepts/logging/sessions/sessions-overview.mdx
+++ b/concepts/logging/sessions/sessions-overview.mdx
@@ -13,7 +13,7 @@ A Session is **a collection of Traces, Events, and Spans emitted by your Applica
 
 ## Introduction
 
-Imagine you're building an LLM-powered customer service chat application. During development or in production, you will want to see how a single multi-turn conversation flows from user prompt, to tool calling, to model response. **Sessions** solve this problem by bundling log stream traces into a cohesive unit, so you can observe and evaluate an entire LLM interaction from start to finish.
+Imagine you're building an LLM-powered customer service chat application. During development or in production, you will want to see how a multi-turn conversation flows from user prompt, to tool calling, to model response. **Sessions** solve this problem by bundling log stream traces into a cohesive unit, so you can observe and evaluate an entire agent interaction from start to finish.
 
 ## Core Concepts
 


### PR DESCRIPTION
## Describe your changes

Removing references to experiments from sessions docs as sessions are not supported in experiments.

## Shortcut ticket

[SC-33876](https://app.shortcut.com/galileo/story/33876/remove-session-notes-on-comparing-evaluation-runs)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - All checks have passed
- [x] - I have reviewed broken links either from the checks, or by running `mintlify broken-links` and I haven't introduced any new broken links
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
