### PR TITLE
Fixing logger call to use parameters not constructor object

### DIFF
--- a/snippets/code/typescript/concepts/experiments/langgraph-callback.mdx
+++ b/snippets/code/typescript/concepts/experiments/langgraph-callback.mdx
@@ -7,12 +7,12 @@ const logger = getLogger();
 const isInExperiment = logger.currentParent() !== undefined;
 
 // Create the callback checking to see if we are in an experiment
-// If we are, set start_new_trace and flush_on_chain_end to False
+// If we are, set startNewTrace and flushOnChainEnd to false
 // so that the existing trace is used, and not flushed
-const galileoCallback = GalileoCallback({
-    galileoLogger: logger,
-    startNewTrace: !isInExperiment,
-    flushOnChainEnd: !isInExperiment,
-});
+const galileoCallback = new GalileoCallback(
+    logger,          // galileoLogger
+    !isInExperiment, // startNewTrace
+    !isInExperiment, // flushOnChainEnd
+);
 const callbacks = [galileoCallback];
 ```

--- a/snippets/code/typescript/sdk/wrappers/langchain-custom-logger.mdx
+++ b/snippets/code/typescript/sdk/wrappers/langchain-custom-logger.mdx
@@ -10,8 +10,8 @@ const logger = new GalileoLogger({
 
 // Create a callback with the custom logger
 const callback = new GalileoCallback(
-  galileoLogger: logger, // Optional custom logger
-  startNewTrace: true,   // Whether to start a new trace for each chain
-  flushOnChainEnd: true, // Whether to flush traces when chains end
+  logger, // Optional custom logger
+  true,   // Whether to start a new trace for each chain
+  true, // Whether to flush traces when chains end
 );
 ```

--- a/snippets/code/typescript/sdk/wrappers/langchain-custom-logger.mdx
+++ b/snippets/code/typescript/sdk/wrappers/langchain-custom-logger.mdx
@@ -9,9 +9,9 @@ const logger = new GalileoLogger({
 });
 
 // Create a callback with the custom logger
-const callback = new GalileoCallback({
+const callback = new GalileoCallback(
   galileoLogger: logger, // Optional custom logger
   startNewTrace: true,   // Whether to start a new trace for each chain
   flushOnChainEnd: true, // Whether to flush traces when chains end
-});
+);
 ```


### PR DESCRIPTION
## Describe your changes

Small nit - using parameters not constructor object for callback

## Shortcut ticket

None

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
