### PR TITLE
Fixing experiment icons

### DIFF
--- a/concepts/experiments/running-experiments.mdx
+++ b/concepts/experiments/running-experiments.mdx
@@ -30,13 +30,13 @@ Experiments fit both into the initial prompt engineering and model selection pha
 AI Engineers and data scientists can use experiments in notebooks or in simple applications to test out prompts or different models. AI Engineers can then add experiments into their production apps allowing these experiments to be run against complex applications or scenarios, including RAG and agentic flows.
 
 <CardGroup cols={2}>
-<Card title="Experiments SDK overview" icon="python" horizontal href="/sdk-api/experiments/experiments">
+<Card title="Experiments SDK overview" icon="code" horizontal href="/sdk-api/experiments/experiments">
     Learn how to run experiments with multiple data points using datasets and prompt templates
 </Card>
-<Card title="Datasets SDK overview" icon="python" horizontal href="/sdk-api/experiments/datasets">
+<Card title="Datasets SDK overview" icon="code" horizontal href="/sdk-api/experiments/datasets">
     Learn how to create and manage datasets for use in your experiments with our SDKs
 </Card>
-<Card title="Prompts SDK overview" icon="python" horizontal href="/sdk-api/experiments/prompts">
+<Card title="Prompts SDK overview" icon="code" horizontal href="/sdk-api/experiments/prompts">
     Learn how to create and use prompt templates in experiments
 </Card>
 </CardGroup>
@@ -80,13 +80,13 @@ To learn more about running experiments in code, and to get started, see our [Ex
 ## Next steps
 
 <CardGroup cols={2}>
-<Card title="Experiments SDK overview" icon="python" horizontal href="/sdk-api/experiments/experiments">
+<Card title="Experiments SDK overview" icon="code" horizontal href="/sdk-api/experiments/experiments">
     Learn how to run experiments with multiple data points using datasets and prompt templates
 </Card>
-<Card title="Datasets SDK overview" icon="python" horizontal href="/sdk-api/experiments/datasets">
+<Card title="Datasets SDK overview" icon="code" horizontal href="/sdk-api/experiments/datasets">
     Learn how to create and manage datasets for use in your experiments with our SDKs
 </Card>
-<Card title="Prompts SDK overview" icon="python" horizontal href="/sdk-api/experiments/prompts">
+<Card title="Prompts SDK overview" icon="code" horizontal href="/sdk-api/experiments/prompts">
     Learn how to create and use prompt templates in experiments
 </Card>
 </CardGroup>


### PR DESCRIPTION
## Describe your changes

Changing icons in the cards in the run experiments in code page to be code, not Python as they point to SDK docs for Python and TypeScript.

## Shortcut ticket

None - small nit.

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
