### PR TITLE
fix: Update context relevance metric definition (it uses LLM as judge instead of old embedding based)

### DIFF
--- a/concepts/metrics/response-quality/context-relevance.mdx
+++ b/concepts/metrics/response-quality/context-relevance.mdx
@@ -7,17 +7,14 @@ import { Pill } from "/snippets/components/pill.mdx";
 import { DefinitionCard } from "/snippets/components/definition-card.mdx";
 
 <DefinitionCard>
-  <strong>Context Relevance</strong> measures how relevant (or similar) the context provided was to the user query.
+  <strong>Context Relevance</strong> measures if the context has enough information to answer the user query.
 </DefinitionCard>
 
 ## Context relevance
 
-Context Relevance measures how relevant (or similar) the context provided was to the user query. This metric requires {context} and {query} slots in your data, as well as embeddings for them (i.e. `{context_embedding}`, `{query_embedding}`.
+Context Relevance measures if the context has enough information to answer the user query.
 
-Context Relevance is a relative metric. High Context Relevance values indicate significant similarity or relevance. Low Context Relevance values are a sign that you need to augment your knowledge base or vector DB with additional documents, modify your retrieval strategy, or use better embeddings. 
-
-## Requirements
-Context and Query Embeddings are required to compute Context Relevance. If you're seeing a _Missing Embeddings_ error, it means you didn't log your embeddings correctly.
+High Context Relevance values indicate strong confidence that there is enough context to answer the question. Low Context Relevance values are a sign that you need to increase your Top K, modify your retrieval strategy, or use better embeddings. 
 
 <Note type="info">
   Context Relevance is differentiated from [Context Adherence](/concepts/metrics/response-quality/context-adherence): Context Relevance evaluates whether the retrieved context is relevant to a user's query whereas Context Adherence determines how well the response aligns to provided context. 


### PR DESCRIPTION
## Describe your changes

What did you change? Why did you change it?

## Shortcut ticket

For Galileo internally raised PRs only, please update this with your shortcut ticket.

[SC-number](link)

> Keep the formatting, replacing `SC-number` with the shortcut ticket, e.g. [SC-12345], and adding the link to the ticket correctly in the brackets. This format is important as it allows Shortcut to track the ticket, moving the status to in review, then merged once the ticket is merged.

For external PRs, please add the issue (just put the number after the # below, and GitHub will automatically create a link):

Issue: #number

## Checklist before requesting a review

- [ ] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [ ] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [ ] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have verified all images and videos match production (or dev for unreleased features)
- [ ] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [ ] - All checks have passed
- [ ] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
