### PR TITLE
Moving uncertainty to luna

### DIFF
--- a/snippets/content/metrics-reference-table.mdx
+++ b/snippets/content/metrics-reference-table.mdx
@@ -35,7 +35,6 @@ import { GalileoScorers } from "galileo";
 | [Tool Errors](/concepts/metrics/agentic/tool-error)                                           | `GalileoScorers.tool_error_rate` |
 | [Tool Selection Quality](/concepts/metrics/agentic/tool-selection-quality)                    | `GalileoScorers.tool_selection_quality` |
 | [Toxicity](/concepts/metrics/safety-and-compliance/toxicity)                                  | `GalileoScorers.input_toxicity`, `GalileoScorers.output_toxicity` |
-| [Uncertainty](/concepts/metrics/model-confidence/uncertainty)                                 | `GalileoScorers.uncertainty` |
 </Tab>
 <Tab title="TypeScript">
 | Metric                                                                                        | Enum Value |
@@ -57,7 +56,6 @@ import { GalileoScorers } from "galileo";
 | [Tool Errors](/concepts/metrics/agentic/tool-error)                                           | `GalileoScorers.ToolErrorRate` |
 | [Tool Selection Quality](/concepts/metrics/agentic/tool-selection-quality)                    | `GalileoScorers.ToolSelectionQuality` |
 | [Toxicity](/concepts/metrics/safety-and-compliance/toxicity)                                  | `GalileoScorers.InputToxicity`, `GalileoScorers.OutputToxicity` |
-| [Uncertainty](/concepts/metrics/model-confidence/uncertainty)                                 | `GalileoScorers.Uncertainty` |
 </Tab>
 </Tabs>
 
@@ -81,6 +79,7 @@ If you are using the [Galileo Luna-2 model](/concepts/luna/luna), then use these
 | [Tool Errors](/concepts/metrics/agentic/tool-error)                                           | `GalileoScorers.tool_error_rate_luna` |
 | [Tool Selection Quality](/concepts/metrics/agentic/tool-selection-quality)                    | `GalileoScorers.tool_selection_quality_luna` |
 | [Toxicity](/concepts/metrics/safety-and-compliance/toxicity)                                  | `GalileoScorers.input_toxicity_luna`, `GalileoScorers.output_toxicity_luna` |
+| [Uncertainty](/concepts/metrics/model-confidence/uncertainty)                                 | `GalileoScorers.uncertainty` |
 </Tab>
 <Tab title="TypeScript">
 | Metric                                                                                        | Enum Value |
@@ -97,6 +96,7 @@ If you are using the [Galileo Luna-2 model](/concepts/luna/luna), then use these
 | [Tool Errors](/concepts/metrics/agentic/tool-error)                                           | `GalileoScorers.ToolErrorRateLuna` |
 | [Tool Selection Quality](/concepts/metrics/agentic/tool-selection-quality)                    | `GalileoScorers.ToolSelectionQualityLuna` |
 | [Toxicity](/concepts/metrics/safety-and-compliance/toxicity)                                  | `GalileoScorers.InputToxicityLuna`, `GalileoScorers.OutputToxicityLuna` |
+| [Uncertainty](/concepts/metrics/model-confidence/uncertainty)                                 | `GalileoScorers.Uncertainty` |
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Describe your changes

Moving the uncertainty metric to the luna section of the reference table

## Shortcut ticket

[SC-36340](https://app.shortcut.com/galileo/story/36340/qa2-0-docs-metrics-some-mistakes-regarding-luna)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have verified all images and videos match production (or dev for unreleased features)
- [x] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [x] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
