### PR TITLE
Nit/Template Update: Add related resources CTA component + template metric

### DIFF
--- a/.github/templates/template-metric.md
+++ b/.github/templates/template-metric.md
@@ -3,7 +3,9 @@ title: Metric Title in Title Case
 description: Description in sentence case
 ---
 
+import { DefinitionCard } from '@snippets/components/DefinitionCard';
 import { MetricWhenToUse } from "/snippets/components/metric-when-to-use.mdx";
+import { RelatedResources } from '@snippets/components/related-resources';
 
 > This template includes writing instructions and boilerplate text that you can customize, use as-is, or completely replace with your own text. This text is indicated in (parentheses). Make sure you replace the placeholders with your own text.
 
@@ -167,17 +169,18 @@ OPTIONAL
 </Note>
 
 > Related Resources Component, feel free to add in any related resources you think are relevant to the metric.
+> If there are no related resources / assets, the component will not be rendered if the section is deleted.
+
+
 <RelatedResources 
   metricName="(Metric Name)"
   howToGuides={[
-    { title: "How to Implement Action Advancement", url: "/how-to-guides/action-advancement" },
-    { title: "Best Practices for Agent Development", url: "/how-to-guides/agent-best-practices" }
+    { title: "(Title of How to Guide)", url: "(relative path to how to guide)" },
   ]}
   relatedConcepts={[
-    { title: "Agent Efficiency", url: "/concepts/metrics/agentic/agent-efficiency" },
-    { title: "Multi-Agent Systems", url: "/concepts/agents" }
+    { title: "(Concept Doc)", url: "(Relative Path to concept doc)" },
   ]}
   externalResources={[
-    { title: "Agent Development Guide", url: "https://example.com/agent-guide" }
+    { title: "(blog or video could go here)", url: "(link to blog or video)" }
   ]}
 />

--- a/.github/templates/template-metric.md
+++ b/.github/templates/template-metric.md
@@ -166,18 +166,18 @@ OPTIONAL
 (Tip on how to best use with other metrics or other nuance to add in if applicable)
 </Note>
 
-
-## Related Resources
-If you would like to dive deeper or start implementing (metric), check out the following resources:
-
-### How-to guides:
-- [Link to relevant how-to guide 1]
-- [Link to relevant how-to guide 2]
-
-### Related Concepts:
-- [Link to related concept 1]
-- [Link to related concept 2]
-
-### External Resources:
-- [Link to external resource 1]
-- [Link to external resource 2]
+> Related Resources Component, feel free to add in any related resources you think are relevant to the metric.
+<RelatedResources 
+  metricName="(Metric Name)"
+  howToGuides={[
+    { title: "How to Implement Action Advancement", url: "/how-to-guides/action-advancement" },
+    { title: "Best Practices for Agent Development", url: "/how-to-guides/agent-best-practices" }
+  ]}
+  relatedConcepts={[
+    { title: "Agent Efficiency", url: "/concepts/metrics/agentic/agent-efficiency" },
+    { title: "Multi-Agent Systems", url: "/concepts/agents" }
+  ]}
+  externalResources={[
+    { title: "Agent Development Guide", url: "https://example.com/agent-guide" }
+  ]}
+/>

--- a/snippets/components/related-resources.mdx
+++ b/snippets/components/related-resources.mdx
@@ -1,0 +1,54 @@
+export const RelatedResources = ({ 
+  howToGuides = [], 
+  relatedConcepts = [], 
+  externalResources = [],
+  metricName = "this metric"
+}) => {
+  return (
+    <div>
+      <h2>Related Resources</h2>
+      <p>
+        If you would like to dive deeper or start implementing {metricName}, check out the following resources:
+      </p>
+
+      {howToGuides.length > 0 && (
+        <div style={{ marginBottom: "1.5rem" }}>
+          <h3>How-to guides:</h3>
+          <ul>
+            {howToGuides.map((guide, index) => (
+              <li key={index}>
+                <a href={guide.url}>{guide.title}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {relatedConcepts.length > 0 && (
+        <div style={{ marginBottom: "1.5rem" }}>
+          <h3>Related Concepts:</h3>
+          <ul>
+            {relatedConcepts.map((concept, index) => (
+              <li key={index}>
+                <a href={concept.url}>{concept.title}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {externalResources.length > 0 && (
+        <div style={{ marginBottom: "1.5rem" }}>
+          <h3>External Resources:</h3>
+          <ul>
+            {externalResources.map((resource, index) => (
+              <li key={index}>
+                <a href={resource.url}>{resource.title}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Describe your changes

Add footer CTA component for related resources. 

## Shortcut ticket

For Galileo internally raised PRs only, please update this with your shortcut ticket.

[SC-39105](https://app.shortcut.com/galileo/story/39105/docs-individual-metric-page-template-update-add-component-to-cta-section-for-bottom-of-the-page)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have verified all images and videos match production (or dev for unreleased features)
- [x] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [x] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
