### PR TITLE
Add CTA to create galileo account in quickstart

### DIFF
--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -3,6 +3,8 @@ title: Log Your First Trace
 description: Learn how to log your first trace with Galileo
 ---
 
+{/*<!-- markdownlint-disable MD044 -->*/}
+
 import {LLMFrameworkSelector} from '/snippets/components/LLMFrameworkSelector.jsx';
 import {LLMFrameworkSelectorComponent} from '/snippets/components/LLMFrameworkSelectorComponent.jsx';
 
@@ -10,6 +12,8 @@ import OpenAI from "/snippets/content/get-started/quickstart/openai.mdx"
 import AzureOpenAI from "/snippets/content/get-started/quickstart/azure.mdx"
 import Anthropic from "/snippets/content/get-started/quickstart/anthropic.mdx"
 import Gemini from "/snippets/content/get-started/quickstart/gemini.mdx"
+
+{/*<!-- markdownlint-enable MD044 -->*/}
 
 ## Create a Galileo Account
 


### PR DESCRIPTION
## Describe your changes
Adding a small CTA to create a Galileo account from the quickstart page

<img width="767" height="430" alt="image" src="https://github.com/user-attachments/assets/c605a3f2-28df-43df-b99e-ba2edc16bae3" />

