### PR TITLE
Fixing full screen video

### DIFF
--- a/.github/templates/template-cookbook.md
+++ b/.github/templates/template-cookbook.md
@@ -9,7 +9,15 @@ description: Description in sentence case
 
 (Add a video link to a video walking through this guide)
 You can also watch the video walkthrough [on the Galileo YouTube]((link here)).
-<iframe width="560" height="315" src="https://www.youtube.com/embed/" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 ## Overview
 

--- a/.github/templates/template-how-to.md
+++ b/.github/templates/template-how-to.md
@@ -9,7 +9,15 @@ description: Description in sentence case
 
 (Add a video link to a video walking through this guide)
 You can also watch the video walkthrough [on the Galileo YouTube]((link here)).
-<iframe width="560" height="315" src="https://www.youtube.com/embed/" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 ## Overview
 

--- a/.github/templates/template-quickstart.md
+++ b/.github/templates/template-quickstart.md
@@ -9,7 +9,15 @@ description: Description in sentence case
 
 (Add a video link to a video walking through this guide)
 You can also watch the video walkthrough [on the Galileo YouTube]((link here)).
-<iframe width="560" height="315" src="https://www.youtube.com/embed/" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 ## Overview
 

--- a/concepts/metrics/custom-metrics/continuous-learning-via-human-feedback.mdx
+++ b/concepts/metrics/custom-metrics/continuous-learning-via-human-feedback.mdx
@@ -60,15 +60,15 @@ Examples are limited to 15 per metric per project. If you submit more than 15 ex
 ## How to use it
 
 See this video on how to use Continuous Learning via Human Feedback to improve your metric accuracy:
-    <iframe
-    width="560"
-    height="315"
-    src="https://www.youtube.com/embed/Rl8YLFCyoiw"
-    title="YouTube video player"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    ></iframe>
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/Rl8YLFCyoiw"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 ## Which metrics is this supported on?
 

--- a/cookbooks/use-cases/agent-langchain.mdx
+++ b/cookbooks/use-cases/agent-langchain.mdx
@@ -23,7 +23,15 @@ A simple LangChain-powered AI Agent that uses OpenAI's language models and a cus
 - How to structure tools and environment for scalable development
 
 👀 Check out the full [SDK Examples repository on GitHub](https://github.com/rungalileo/SDK-Examples), or [watch the video walkthrough](https://youtu.be/kx0LbMKZFUg) in tandem.
-<iframe width="560" height="315" src="https://www.youtube.com/embed/kx0LbMKZFUg?si=kW2GKh6cSvrb21ZT" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/kx0LbMKZFUg"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 ### Requirements
 

--- a/cookbooks/use-cases/agent-weather-vibes-app.mdx
+++ b/cookbooks/use-cases/agent-weather-vibes-app.mdx
@@ -31,7 +31,14 @@ The application leverages multiple tools to create its final end result:
 
 Finally, we'll run this application to demonstrate [Galileo's Agent Evaluation functionality](https://www.galileo.ai/blog/introducing-agentic-evaluations), where it will determine the success of each run and tool call. You can also follow along [on YouTube](https://youtu.be/h6Ui2kpstR4?si=Bek5yPt6vWtyL0U9).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/h6Ui2kpstR4?si=PMVHWPlGN_A7IQ8v" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/h6Ui2kpstR4"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 ### Requirements
 

--- a/cookbooks/use-cases/multi-agent-langgraph/multi-agent-langgraph.mdx
+++ b/cookbooks/use-cases/multi-agent-langgraph/multi-agent-langgraph.mdx
@@ -24,7 +24,15 @@ By the end of this tutorial, you'll be able to:
 - View and understand session level metrics
 
 You can also watch the video walkthrough [on the Galileo YouTube](https://youtu.be/FZFhLK2xIik).
-<iframe width="560" height="315" src="https://www.youtube.com/embed/FZFhLK2xIik?si=XtY0VUiKhxCkZW1r" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/FZFhLK2xIik"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 ## Background
 

--- a/release-notes.mdx
+++ b/release-notes.mdx
@@ -29,8 +29,14 @@ Enhanced Agent monitoring with Galileo's new custom metric creation flow This fe
 
 This new testing flow enables users to test metrics on past logs and experiments, allowing for quick iteration and validation to ensure the metric is working as expected before deploying to production.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/oYAxfsAOdGU?si=AiIX-2TZs65oa_mP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen>
-</iframe>
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/oYAxfsAOdGU"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
 
 </Update>
 
@@ -341,13 +347,12 @@ As you identify mistakes in your metrics, you can provide ‘feedback' to ‘aut
 This process has shown to increase accuracy of metrics by 20-30%.
 
 <iframe
-width="560"
-height="315"
-src="https://www.youtube.com/embed/Rl8YLFCyoiw"
-title="YouTube video player"
-frameborder="0"
-allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-allowfullscreen
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/Rl8YLFCyoiw"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
 ></iframe>
 
 ### Playground improvements


### PR DESCRIPTION
## Describe your changes

Changing YouTube iFrames to match mintlify standard to enable full screen.

## Shortcut ticket

[SC-34052](https://app.shortcut.com/galileo/story/34052/qa2-0-docs-not-possible-to-watch-video-in-full-screen)

## Checklist before requesting a review

- [ ] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [ ] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [ ] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have verified all images and videos match production (or dev for unreleased features)
- [ ] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [ ] - All checks have passed
- [ ] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
