### PR TITLE
fix(scorers): Modify wording around providing rubric and not response type for Custom LLM Metrics

### DIFF
--- a/concepts/metrics/custom-metrics/custom-metrics-ui-llm.mdx
+++ b/concepts/metrics/custom-metrics/custom-metrics-ui-llm.mdx
@@ -114,6 +114,16 @@ Set false if the guidance is not completely followed
 
 This establishes a clear evaluation rubric where "completely followed" is the criterion for a passing grade, while any deviation from the guidance results in a failing grade.
 
+Also we recommend not to write any instructions in the prompt regarding the response format.
+{/*<!-- markdownlint-enable MD013 -->*/}
+
+Avoid statements like:
+
+```output
+Only return a single word,  True or False
+Return as a JSON
+```
+
 <Info>
 See our [prompt engineering guide](/concepts/metrics/custom-metrics/prompt-engineering) to learn more about writing an effective prompt, and what happens behind the scenes with your prompts.
 </Info>


### PR DESCRIPTION
## Describe your changes

What did you change? Why did you change it?

## Shortcut ticket

For Galileo internally raised PRs only, please update this with your shortcut ticket.

[SC-number](link)

> Keep the formatting, replacing `SC-number` with the shortcut ticket, e.g. [SC-12345], and adding the link to the ticket correctly in the brackets. This format is important as it allows Shortcut to track the ticket, moving the status to in review, then merged once the ticket is merged.

For external PRs, please add the issue (just put the number after the # below, and GitHub will automatically create a link):

Issue: #number

## Checklist before requesting a review

- [ ] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [ ] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [ ] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have verified all images and videos match production (or dev for unreleased features)
- [ ] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [ ] - All checks have passed
- [ ] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
