### PR TITLE
fix: Docs for composites should reflect new boolean output structure

### DIFF
--- a/concepts/metrics/custom-metrics/composite-metrics.mdx
+++ b/concepts/metrics/custom-metrics/composite-metrics.mdx
@@ -42,13 +42,17 @@ def scorer_fn(*, step_object: LlmSpan, **kwargs) -> float:
     # Boolean metrics like correctness return a list of 0/1 values,
     # one per judge. Compute the fraction of judges that agreed.
     correctness_votes = step_object.metrics[GalileoMetrics.correctness]
-    correctness_score = sum(correctness_votes) / len(correctness_votes) if correctness_votes else 0.0
+    correctness_score = (
+        sum(correctness_votes) / len(correctness_votes)
+        if correctness_votes else 0.0
+    )
 
     if correctness_score < 0.7:
-        return 0.0  # Skip adherence calculation for incorrect inputs
+        return 0.0
 
-    # Calculate adherence for correct inputs
-    adherence = step_object.metrics[GalileoMetrics.context_adherence]
+    adherence = step_object.metrics[
+        GalileoMetrics.context_adherence
+    ]
     return adherence
 ```
 
@@ -177,7 +181,8 @@ def scorer_fn(*, step_object: LlmSpan, **kwargs) -> float:
 
 Different Galileo metrics return different value types:
 
-- **Float metrics** (e.g. `context_adherence`, `context_relevance`) return a single `float` between 0 and 1.
+- **Float metrics** (e.g. `completeness`) return a single
+  `float` between 0 and 1.
 - **Boolean metrics** (e.g. `correctness`) are evaluated by multiple judges and return a `list[int]` at the root level, where each element is `0` (false) or `1` (true) — one value per judge.
 
 When using a boolean metric in your composite scorer, you must handle the list:
@@ -188,7 +193,10 @@ correctness_votes = step_object.metrics[GalileoMetrics.correctness]
 # e.g. [1, 0, 1] when 3 judges ran
 
 # Get the fraction of judges that agreed (0.0 – 1.0)
-correctness_score = sum(correctness_votes) / len(correctness_votes) if correctness_votes else 0.0
+correctness_score = (
+    sum(correctness_votes) / len(correctness_votes)
+    if correctness_votes else 0.0
+)
 
 # Or check if any/all judges agreed
 passed_any = any(v == 1 for v in correctness_votes)

--- a/concepts/metrics/custom-metrics/composite-metrics.mdx
+++ b/concepts/metrics/custom-metrics/composite-metrics.mdx
@@ -39,9 +39,12 @@ Calculate a metric only when another metric meets certain criteria:
 from galileo import GalileoMetrics, LlmSpan
 
 def scorer_fn(*, step_object: LlmSpan, **kwargs) -> float:
-    # Only calculate adherence if correctness score is high
-    correctness = step_object.metrics[GalileoMetrics.correctness]
-    if correctness < 0.7:
+    # Boolean metrics like correctness return a list of 0/1 values,
+    # one per judge. Compute the fraction of judges that agreed.
+    correctness_votes = step_object.metrics[GalileoMetrics.correctness]
+    correctness_score = sum(correctness_votes) / len(correctness_votes) if correctness_votes else 0.0
+
+    if correctness_score < 0.7:
         return 0.0  # Skip adherence calculation for incorrect inputs
 
     # Calculate adherence for correct inputs
@@ -168,6 +171,28 @@ def scorer_fn(*, step_object: LlmSpan, **kwargs) -> float:
 
     # Use the metric values in your logic
     return (adherence + custom_score) / 2
+```
+
+### Boolean vs. float metrics
+
+Different Galileo metrics return different value types:
+
+- **Float metrics** (e.g. `context_adherence`, `context_relevance`) return a single `float` between 0 and 1.
+- **Boolean metrics** (e.g. `correctness`) are evaluated by multiple judges and return a `list[int]` at the root level, where each element is `0` (false) or `1` (true) — one value per judge.
+
+When using a boolean metric in your composite scorer, you must handle the list:
+
+```python
+# Boolean metric — returns a list of 0/1 values, one per judge
+correctness_votes = step_object.metrics[GalileoMetrics.correctness]
+# e.g. [1, 0, 1] when 3 judges ran
+
+# Get the fraction of judges that agreed (0.0 – 1.0)
+correctness_score = sum(correctness_votes) / len(correctness_votes) if correctness_votes else 0.0
+
+# Or check if any/all judges agreed
+passed_any = any(v == 1 for v in correctness_votes)
+passed_all = all(v == 1 for v in correctness_votes)
 ```
 
 ## Complete example: multi-level session metric

--- a/concepts/metrics/custom-metrics/custom-metrics-ui-code.mdx
+++ b/concepts/metrics/custom-metrics/custom-metrics-ui-code.mdx
@@ -149,7 +149,10 @@ def scorer_fn(*, step_object: LlmSpan, **kwargs) -> float:
     # Boolean metrics (e.g. correctness) return a list of 0/1 values,
     # one per judge. Use sum()/len() to get the fraction that passed.
     correctness_votes = step_object.metrics[GalileoMetrics.correctness]
-    correctness_score = sum(correctness_votes) / len(correctness_votes) if correctness_votes else 0.0
+    correctness_score = (
+        sum(correctness_votes) / len(correctness_votes)
+        if correctness_votes else 0.0
+    )
 
     adherence = step_object.metrics[GalileoMetrics.context_adherence]
 

--- a/concepts/metrics/custom-metrics/custom-metrics-ui-code.mdx
+++ b/concepts/metrics/custom-metrics/custom-metrics-ui-code.mdx
@@ -145,11 +145,16 @@ from galileo import GalileoMetrics, LlmSpan
 def scorer_fn(*, step_object: LlmSpan, **kwargs) -> float:
     # Access required metrics via step_object.metrics
     # These metrics were selected in the "Required Metrics" dropdown
-    correctness = step_object.metrics[GalileoMetrics.correctness]
+
+    # Boolean metrics (e.g. correctness) return a list of 0/1 values,
+    # one per judge. Use sum()/len() to get the fraction that passed.
+    correctness_votes = step_object.metrics[GalileoMetrics.correctness]
+    correctness_score = sum(correctness_votes) / len(correctness_votes) if correctness_votes else 0.0
+
     adherence = step_object.metrics[GalileoMetrics.context_adherence]
 
-    # Only calculate adherence if correctness is high
-    if correctness < 0.7:
+    # Only calculate adherence if the majority of judges rated it as correct
+    if correctness_score < 0.7:
         return 0.0
 
     return adherence


### PR DESCRIPTION
## Describe your changes

What did you change? Why did you change it?

## Shortcut ticket

For Galileo internally raised PRs only, please update this with your shortcut ticket.

[SC-number](link)

> Keep the formatting, replacing `SC-number` with the shortcut ticket, e.g. [SC-12345], and adding the link to the ticket correctly in the brackets. This format is important as it allows Shortcut to track the ticket, moving the status to in review, then merged once the ticket is merged.

For external PRs, please add the issue (just put the number after the # below, and GitHub will automatically create a link):

Issue: #number

## Checklist before requesting a review

- [ ] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [ ] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [ ] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have verified all images and videos match production (or dev for unreleased features)
- [ ] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [ ] - All checks have passed
- [ ] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
