### PR TITLE
docs: add redacted data OTEL span attributes

### DIFF
--- a/how-to-guides/third-party-integrations/otel.mdx
+++ b/how-to-guides/third-party-integrations/otel.mdx
@@ -348,6 +348,13 @@ span.set_attribute("gen_ai.response.content", ai_response)
 span.set_attribute("gen_ai.usage.prompt_tokens", 150)
 span.set_attribute("gen_ai.usage.completion_tokens", 75)
 span.set_attribute("gen_ai.usage.total_tokens", 225)
+
+# Redacted data (privacy/compliance)
+# Use these to send redacted versions of input/output alongside the originals.
+# When present, Galileo stores both versions and can display the redacted version
+# to users who don't have permission to view the original data.
+span.set_attribute("galileo.input.redacted", redacted_user_input)
+span.set_attribute("galileo.output.redacted", redacted_ai_response)
 ```
 
 </Step>

--- a/how-to-guides/third-party-integrations/otel.mdx
+++ b/how-to-guides/third-party-integrations/otel.mdx
@@ -334,6 +334,10 @@ For advanced use cases, you can also manually add custom attributes to enhance y
 <Steps>
 <Step title="Span attributes">
 
+<Note>
+**Redacted data attributes:** You can attach `galileo.input.redacted` and `galileo.output.redacted` to any span in the trace (root or child) to send redacted versions of input and output alongside the originals. Galileo stores both and can restrict the original data to privileged users. Each attribute is independent — you can set one without the other for partial redaction.
+</Note>
+
 ```python
 # Model information
 span.set_attribute("gen_ai.system", "openai")
@@ -350,9 +354,10 @@ span.set_attribute("gen_ai.usage.completion_tokens", 75)
 span.set_attribute("gen_ai.usage.total_tokens", 225)
 
 # Redacted data (privacy/compliance)
-# Use these to send redacted versions of input/output alongside the originals.
-# When present, Galileo stores both versions and can display the redacted version
-# to users who don't have permission to view the original data.
+# Replace sensitive content with your own redaction logic
+redacted_user_input = mask_pii(user_prompt)        # e.g. "My SSN is ***-**-****"
+redacted_ai_response = mask_pii(ai_response)       # e.g. "Your account *** is active"
+
 span.set_attribute("galileo.input.redacted", redacted_user_input)
 span.set_attribute("galileo.output.redacted", redacted_ai_response)
 ```


### PR DESCRIPTION
## Describe your changes

Add documentation for `galileo.input.redacted` and `galileo.output.redacted` OTEL span attributes to the OpenTelemetry integration guide. These attributes allow users to send redacted versions of input/output alongside the originals for privacy and compliance purposes. When present, Galileo stores both versions and can display the redacted version to users without permission to view the original data.

## Shortcut ticket

[SC-60546](https://app.shortcut.com/galileo/story/60546)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have verified all images and videos match production (or dev for unreleased features)
- [x] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [ ] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release