### PR TITLE
docs(prompts): update prompts docs and deprecate old

### DIFF
--- a/sdk-api/experiments/prompts.mdx
+++ b/sdk-api/experiments/prompts.mdx
@@ -5,21 +5,26 @@ description: Learn how to create and use prompt templates in experiments
 
 {/*<!-- markdownlint-disable MD044 -->*/}
 
+import SnippetSdkDatasetsExperimentsPythonBeta from "/snippets/code/python-beta/sdk/datasets/experiments.mdx";
 import SnippetSdkPromptsCreatePython from "/snippets/code/python/sdk/prompts/create.mdx";
-import SnippetSdkPromptsGetPython from "/snippets/code/python/sdk/prompts/get.mdx";
-import SnippetSdkPromptsListPython from "/snippets/code/python/sdk/prompts/list.mdx";
+import SnippetSdkPromptsCreatePythonBeta from "/snippets/code/python-beta/sdk/prompts/create.mdx";
 import SnippetSdkPromptsDeletePython from "/snippets/code/python/sdk/prompts/delete.mdx";
+import SnippetSdkPromptsDeletePythonBeta from "/snippets/code/python-beta/sdk/prompts/delete.mdx";
 import SnippetSdkPromptsExperimentPython from "/snippets/code/python/sdk/datasets/experiments.mdx";
-import SnippetSdkPromptsTestDataPython from "/snippets/code/python/sdk/experiments/test-data.mdx";
+import SnippetSdkPromptsGetPython from "/snippets/code/python/sdk/prompts/get.mdx";
+import SnippetSdkPromptsGetPythonBeta from "/snippets/code/python-beta/sdk/prompts/get.mdx";
+import SnippetSdkPromptsListPython from "/snippets/code/python/sdk/prompts/list.mdx";
+import SnippetSdkPromptsListPythonBeta from "/snippets/code/python-beta/sdk/prompts/list.mdx";
 import SnippetSdkPromptsReferenceDataSetPython from "/snippets/code/python/sdk/experiments/reference-dataset.mdx";
+import SnippetSdkPromptsTestDataPython from "/snippets/code/python/sdk/experiments/test-data.mdx";
 
 import SnippetSdkPromptsCreateTypeScript from "/snippets/code/typescript/sdk/prompts/create.mdx";
-import SnippetSdkPromptsGetTypeScript from "/snippets/code/typescript/sdk/prompts/get.mdx";
-import SnippetSdkPromptsListTypeScript from "/snippets/code/typescript/sdk/prompts/list.mdx";
 import SnippetSdkPromptsDeleteTypeScript from "/snippets/code/typescript/sdk/prompts/delete.mdx";
 import SnippetSdkPromptsExperimentTypeScript from "/snippets/code/typescript/sdk/datasets/experiments.mdx";
-import SnippetSdkPromptsTestDataTypeScript from "/snippets/code/typescript/sdk/experiments/test-data.mdx";
+import SnippetSdkPromptsGetTypeScript from "/snippets/code/typescript/sdk/prompts/get.mdx";
+import SnippetSdkPromptsListTypeScript from "/snippets/code/typescript/sdk/prompts/list.mdx";
 import SnippetSdkPromptsReferenceDataSetTypeScript from "/snippets/code/typescript/sdk/experiments/reference-dataset.mdx";
+import SnippetSdkPromptsTestDataTypeScript from "/snippets/code/typescript/sdk/experiments/test-data.mdx";
 
 {/*<!-- markdownlint-enable MD044 -->*/}
 
@@ -38,6 +43,7 @@ The **Prompts** page of the Galileo console shows you the existing prompts assoc
 
 <CodeGroup>
   <SnippetSdkPromptsCreatePython />
+  <SnippetSdkPromptsCreatePythonBeta />
   <SnippetSdkPromptsCreateTypeScript />
 </CodeGroup>
 
@@ -68,6 +74,7 @@ Once prompts have been created in Galileo, they can be retrieved by name. For pr
 
 <CodeGroup>
   <SnippetSdkPromptsGetPython />
+  <SnippetSdkPromptsGetPythonBeta />
   <SnippetSdkPromptsGetTypeScript />
 </CodeGroup>
 
@@ -77,6 +84,7 @@ To list all prompt templates in a project or organization:
 
 <CodeGroup>
   <SnippetSdkPromptsListPython />
+  <SnippetSdkPromptsListPythonBeta />
   <SnippetSdkPromptsListTypeScript />
 </CodeGroup>
 
@@ -86,6 +94,7 @@ To delete a prompt:
 
 <CodeGroup>
   <SnippetSdkPromptsDeletePython />
+  <SnippetSdkPromptsDeletePythonBeta />
   <SnippetSdkPromptsDeleteTypeScript />
 </CodeGroup>
 
@@ -95,6 +104,7 @@ Prompts can be used in experiments to evaluate different prompt templates:
 
 <CodeGroup>
   <SnippetSdkPromptsExperimentPython />
+  <SnippetSdkDatasetsExperimentsPythonBeta />
   <SnippetSdkPromptsExperimentTypeScript />
 </CodeGroup>
 

--- a/snippets/code/python-beta/sdk/datasets/experiments.mdx
+++ b/snippets/code/python-beta/sdk/datasets/experiments.mdx
@@ -1,0 +1,20 @@
+```python Python (Beta)
+from galileo import Dataset, Experiment, Metric, Prompt
+
+# Get an existing dataset
+dataset = Dataset.get(name="countries")
+
+# Get an existing prompt
+prompt = Prompt.get(name="geography-prompt")
+
+# Run an experiment with the dataset and prompt
+experiment = Experiment(
+    name="geography-experiment",
+    dataset=dataset,
+    prompt=prompt,
+    metrics=[Metric.scorers.completeness],
+    project_name="my-project",
+)
+experiment.create()
+result = experiment.run()
+```

--- a/snippets/code/python-beta/sdk/datasets/experiments.mdx
+++ b/snippets/code/python-beta/sdk/datasets/experiments.mdx
@@ -3,18 +3,22 @@ from galileo import Dataset, Experiment, Metric, Prompt
 
 # Get an existing dataset
 dataset = Dataset.get(name="countries")
+if dataset is None:
+    raise ValueError("Dataset 'countries' not found")
 
 # Get an existing prompt
 prompt = Prompt.get(name="geography-prompt")
+if prompt is None:
+    raise ValueError("Prompt 'geography-prompt' not found")
 
-# Run an experiment with the dataset and prompt
+# Create and run the experiment in one step
+# (create() triggers the run automatically)
 experiment = Experiment(
     name="geography-experiment",
     dataset=dataset,
     prompt=prompt,
-    metrics=[Metric.scorers.completeness],
+    metrics=[Metric.metrics.completeness],
     project_name="my-project",
 )
 experiment.create()
-result = experiment.run()
 ```

--- a/snippets/code/python-beta/sdk/prompts/create.mdx
+++ b/snippets/code/python-beta/sdk/prompts/create.mdx
@@ -1,0 +1,18 @@
+```python Python (Beta)
+from galileo import Message, MessageRole, Prompt
+
+# Create a prompt with system and user messages
+prompt = Prompt(
+    name="storyteller-prompt",
+    messages=[
+        Message(role=MessageRole.system,
+                content="You are a great storyteller."),
+        Message(role=MessageRole.user,
+                content="""
+                Please write a short story about
+                the following topic: {{topic}}
+                """)
+    ],
+)
+prompt.create()
+```

--- a/snippets/code/python-beta/sdk/prompts/delete.mdx
+++ b/snippets/code/python-beta/sdk/prompts/delete.mdx
@@ -1,0 +1,7 @@
+```python Python (Beta)
+from galileo import Prompt
+
+# Get and delete a prompt
+prompt = Prompt.get(name="storyteller-prompt")
+prompt.delete()
+```

--- a/snippets/code/python-beta/sdk/prompts/delete.mdx
+++ b/snippets/code/python-beta/sdk/prompts/delete.mdx
@@ -3,5 +3,7 @@ from galileo import Prompt
 
 # Get and delete a prompt
 prompt = Prompt.get(name="storyteller-prompt")
+if prompt is None:
+    raise ValueError("Prompt 'storyteller-prompt' not found")
 prompt.delete()
 ```

--- a/snippets/code/python-beta/sdk/prompts/get.mdx
+++ b/snippets/code/python-beta/sdk/prompts/get.mdx
@@ -1,0 +1,6 @@
+```python Python (Beta)
+from galileo import Prompt
+
+# Get an existing prompt
+prompt = Prompt.get(name="storyteller-prompt")
+```

--- a/snippets/code/python-beta/sdk/prompts/list.mdx
+++ b/snippets/code/python-beta/sdk/prompts/list.mdx
@@ -1,0 +1,10 @@
+```python Python (Beta)
+from galileo import Prompt
+
+# List all prompt templates
+templates = Prompt.list()
+
+# Print template names
+for template in templates:
+    print(f"Template: {template.name}")
+```


### PR DESCRIPTION
## Describe your changes

Updated prompt docs to reflect new way of using SDK

Link to the collab notebook with evidence:
https://colab.research.google.com/drive/1gMEyo9uQeWfiQ7R3vRQ8spKQhUfBhzfc?usp=sharing

## Shortcut ticket

For Galileo internally raised PRs only, please update this with your shortcut ticket.

[SC-60524](https://app.shortcut.com/galileo/story/60524/create-documentation-snippets-for-prompts)

> Keep the formatting, replacing `SC-number` with the shortcut ticket, e.g. [SC-12345], and adding the link to the ticket correctly in the brackets. This format is important as it allows Shortcut to track the ticket, moving the status to in review, then merged once the ticket is merged.

For external PRs, please add the issue (just put the number after the # below, and GitHub will automatically create a link):

Issue: #number

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have verified all images and videos match production (or dev for unreleased features)
- [x] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [x] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
