### PR TITLE
docs(strands): document opt-in for experimental OTEL semantic conventions

### DIFF
--- a/sdk-api/third-party-integrations/opentelemetry-and-openinference/strands-agents.mdx
+++ b/sdk-api/third-party-integrations/opentelemetry-and-openinference/strands-agents.mdx
@@ -49,6 +49,29 @@ When you run your Strands Agent code, traces will be logged to Galileo.
 </Step>
 </Steps>
 
+## Opt in to experimental OpenTelemetry semantic conventions
+
+Starting in `strands-agents` v1.34.0, the Strands Agents SDK can emit generative AI traces using either the legacy OpenTelemetry semantic conventions or the newer experimental conventions:
+
+- **Legacy mode** (default) — uses attributes such as `gen_ai.system` along with legacy event shapes.
+- **Experimental mode** — follows the latest OpenTelemetry generative AI semantic conventions, using `gen_ai.provider.name` and structured `gen_ai.client.inference.operation.details` events that carry inputs, outputs, and system instructions.
+
+Galileo automatically detects and maps both modes, so traces from either mode will appear in your Galileo Log stream without any changes to your Galileo setup.
+
+If you want to opt in to the experimental conventions, set the following environment variable before your Strands Agent starts:
+
+<CodeGroup>
+
+```ini .env
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+```
+
+</CodeGroup>
+
+<Note>
+`OTEL_SEMCONV_STABILITY_OPT_IN` is read by the Strands Agents SDK at startup. Make sure it is exported in your process environment (or loaded from your `.env` file) before `StrandsTelemetry` is initialized.
+</Note>
+
 ## Full example
 
 Here is a full example based off the [Strands Agent quickstart](https://strandsagents.com/latest/documentation/docs/user-guide/quickstart/). You can find this project in the [Galileo SDK examples repo](https://github.com/rungalileo/sdk-examples/tree/main/python/agent/strands-agent).


### PR DESCRIPTION
## Describe your changes

Adds a new section to the Strands Agents integration page explaining how to opt in to the experimental OpenTelemetry generative AI semantic conventions introduced in `strands-agents` v1.34.0.

- New section "Opt in to experimental OpenTelemetry semantic conventions" in `sdk-api/third-party-integrations/opentelemetry-and-openinference/strands-agents.mdx`
- Explains legacy vs experimental modes (controlled by `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`)
- Emphasizes that Galileo detects and maps both modes seamlessly — no Galileo-side changes required
- Framed mode-agnostic since legacy is still the Strands SDK default
- Complements the backend support shipped in [sc-59586](https://app.shortcut.com/galileo/story/59586) / rungalileo/api#6262

No changes to other Strands references — remaining mentions are card links and the integrations table, which don't need content updates.

## Shortcut ticket

[SC-62086](https://app.shortcut.com/galileo/story/62086)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [x] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [x] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [x] - I have verified all images and videos are clear, with appropriate zoom
- [x] - I have verified all images and videos match production (or dev for unreleased features)
- [x] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [ ] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release