### PR TITLE
fix(docs): update Cursor MCP setup steps to match current UI

### DIFF
--- a/getting-started/mcp/setup-galileo-mcp.mdx
+++ b/getting-started/mcp/setup-galileo-mcp.mdx
@@ -69,7 +69,7 @@ Reload VS Code by opening the Command Palette and running **"Developer: Reload W
 Open the Cursor command palette (`Ctrl + Shift + P` on Windows/Linux, or `Cmd + Shift + P` on Mac), then choose"Open MCP Settings".
 </Step>
 <Step title="Open the MCP server configuration file">
-Select **New MCP Server** to open the `mcp.json` MCP configuration file.
+Click on **Add Custom MCP** to open the `mcp.json` MCP configuration file, or **New MCP Server** if you already have other MCP servers configured.
 </Step>
 <Step title="Add the Galileo MCP server configuration">
 Copy and paste the configuration below. Replace `YOUR-API-KEY` with your actual Galileo API key.

--- a/getting-started/mcp/setup-galileo-mcp.mdx
+++ b/getting-started/mcp/setup-galileo-mcp.mdx
@@ -66,7 +66,7 @@ Reload VS Code by opening the Command Palette and running **"Developer: Reload W
 <Tab title="Cursor">
 <Steps>
 <Step title="Open the Tools & MCP settings">
-Open the Cursor command palette (`Ctrl + Shift + P` on Windows/Linux, or `Cmd + Shift + P` on Mac), then choose"Open MCP Settings".
+Open the Cursor command palette (`Ctrl + Shift + P` on Windows/Linux, or `Cmd + Shift + P` on Mac), then choose "Open MCP Settings".
 </Step>
 <Step title="Open the MCP server configuration file">
 Click on **Add Custom MCP** to open the `mcp.json` MCP configuration file, or **New MCP Server** if you already have other MCP servers configured.


### PR DESCRIPTION
## Describe your changes
  The Cursor MCP setup steps referenced a stale UI. Two things were wrong:
                                                                                                                                                     
  1. **Step 1** instructed users to open the command palette and choose "Open MCP Settings", but the current Cursor UI exposes MCP configuration
  under **Settings → Tools & MCP** (opened via `Cmd + ,` / `Ctrl + ,`).                                                                              
  2. **Step 2** said to click **"New MCP Server"**, but the actual button in the current Cursor UI reads **"Add Custom MCP"**.                     
                                                                                                                                                     
  Updated both steps to match the current Cursor settings dialog.                                                                                  
                                                                                                                                                     
  ## Shortcut ticket
                                                                                                                                                     
  [SC-55995](https://app.shortcut.com/galileo/story/55995/update-mcp-server-docs-for-cursor)                                                       
                                                                                            
  ## Checklist before requesting a review
                                         
  - [x] - Is this ready for review? If not, raise as a draft PR
  - [ ] - This deployed to a staging environment correctly                                                                                           
  - [x] - I have reviewed my changes                      
  - [ ] - I have reviewed the deployed version of my changes                                                                                         
  - [x] - I have tested any code that is added or updated                                                                                          
  - [x] - I have verified all images and videos are clear, with appropriate zoom
  - [x] - I have verified all images and videos match production (or dev for unreleased features)
  - [x] - I have tested that the content matches the functionality in production (or dev for unreleased features)                                    
  - [ ] - All checks have passed                                                                                 
  - [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release 