### PR TITLE
fix /galileo doc link through redirect

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -852,6 +852,10 @@
       "destination": "/what-is-galileo"
     },
     {
+      "source": "/api-reference/getting-started",
+      "destination": "/sdk-api/overview"
+    },
+    {
       "source": "/concepts/experiments/datasets",
       "destination": "/sdk-api/experiments/datasets"
     },

--- a/docs.json
+++ b/docs.json
@@ -848,6 +848,10 @@
       "destination": "/references/faqs/errors-catalog"
     },
     {
+      "source": "/galileo",
+      "destination": "/what-is-galileo"
+    },
+    {
       "source": "/concepts/experiments/datasets",
       "destination": "/sdk-api/experiments/datasets"
     },


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/62684/add-redirect-from-https-docs-galileo-ai-galileo-to-https-docs-galileo-ai