### PR TITLE
Fix example output string in multimodal observability page

### DIFF
--- a/concepts/logging/multimodal-observability.mdx
+++ b/concepts/logging/multimodal-observability.mdx
@@ -78,12 +78,12 @@ logger.add_llm_span(
     input=[{"role": "user", "content": "Analyze all of these files"}],
     output={
         "role": "assistant",
-        "content": "The image is a cat, audio is clear, the PDF is a report.",
+        "content": "The image shows a cat, audio is clear, PDF is a report.",
     },
     model="gpt-5",
 )
 logger.conclude(
-    output="The image is a cat, audio is clear, the PDF is a report."
+    output="The image shows a cat, audio is clear, PDF is a report."
 )
 logger.flush()
 ```


### PR DESCRIPTION
Fixes the LLM output string in the Option 2 code example: 'The image is a cat' → 'The image shows a cat'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)