### PR TITLE
chore: rename "Google A2A" to "A2A"

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -211,11 +211,11 @@
             "group": "Integrations",
             "pages": [
               "sdk-api/third-party-integrations/overview",
+              "sdk-api/third-party-integrations/a2a",
               {
                 "group": "CrewAI",
                 "pages": ["sdk-api/third-party-integrations/crewai/crewai", "sdk-api/third-party-integrations/crewai/experiments"]
               },
-              "sdk-api/third-party-integrations/a2a",
               {
                 "group": "Google ADK",
                 "pages": ["sdk-api/third-party-integrations/google-adk/google-adk-native", "sdk-api/third-party-integrations/opentelemetry-and-openinference/google-adk"]

--- a/sdk-api/third-party-integrations/a2a.mdx
+++ b/sdk-api/third-party-integrations/a2a.mdx
@@ -1,13 +1,13 @@
 ---
-title: Google A2A
-description: Trace Google A2A (Agent-to-Agent) protocol interactions with Galileo for multi-agent observability
+title: A2A
+description: Trace A2A (Agent2Agent) protocol interactions with Galileo for multi-agent observability
 ---
 
 import ConfigureOTelInvVars from "/snippets/content/configure-otel-env-vars.mdx"
 
 import SnippetQuickstartPython from "/snippets/code/python/sdk/otel/a2a/quickstart-example.mdx"
 
-Galileo traces [Google A2A](https://github.com/google/A2A) interactions using the `galileo-a2a` instrumentor — giving you a single distributed trace across agents, including LLM calls, tool use, and cross-agent handoffs.
+Galileo traces [A2A (Agent2Agent)](https://a2a-protocol.org/) interactions using the `galileo-a2a` instrumentor — giving you a single distributed trace across agents, including LLM calls, tool use, and cross-agent handoffs.
 
 ## Setup
 


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/63796/update-docs-to-refer-to-a2a-instead-of-google-a2a