### PR TITLE
docs: expand AWS Bedrock Inference Profiles page

### DIFF
--- a/.vale/styles/config/vocabularies/Galileo-Vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/Galileo-Vocab/accept.txt
@@ -3,7 +3,7 @@ allowfullscreen
 ADK
 adk-python
 APIs
-ARN
+ARN[s]
 [A,a]sync
 Autogen
 [A,a]utogenerate

--- a/sdk-api/third-party-integrations/model-integrations/aws-bedrock/awsbedrock.mdx
+++ b/sdk-api/third-party-integrations/model-integrations/aws-bedrock/awsbedrock.mdx
@@ -3,6 +3,8 @@ title: AWS Bedrock Inference Profiles
 description: Learn how to use AWS Bedrock Inference Profiles with Galileo in a custom deployment.
 ---
 
+import AliasesBedrock from "/snippets/code/multilingual/integrations/custom/aliases/aliases-bedrock.mdx";
+
 Galileo supports AWS Bedrock integration via
 [Inference Profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html).
 This enables the mapping of Galileo-supported model identifiers to an AWS Bedrock
@@ -138,13 +140,10 @@ runs.
 
 ## Supported models
 
-Galileo supports all major Amazon Bedrock foundation models, including:
+Galileo supports the following AWS Bedrock model aliases. Use any of these
+as a key in the `inference_profiles` map of the setup script.
 
-- Anthropic Claude (3, 3.5, 4, Sonnet, Haiku, Opus)
-- Meta Llama (3, 3.1, 3.2)
-- Mistral and Mixtral
-- Amazon Titan
-- Cohere Command
+<AliasesBedrock />
 
 ## Troubleshooting
 

--- a/sdk-api/third-party-integrations/model-integrations/aws-bedrock/awsbedrock.mdx
+++ b/sdk-api/third-party-integrations/model-integrations/aws-bedrock/awsbedrock.mdx
@@ -35,6 +35,18 @@ When you run evaluations or prompts in Galileo, Galileo:
 - Logs results and metrics back to Galileo
 - Your models, data, and billing remain fully in your AWS account.
 
+## Prerequisites
+
+Before running the setup script, make sure you have:
+
+- A **Galileo API key**. The key is tied to a specific Galileo user, and the
+integration will be created or updated under that user.
+- An **AWS IAM role** that Galileo can assume, with:
+  - `bedrock:InvokeModel` permission on the models or inference profiles you intend to use.
+  - A trust policy that allows Galileo to call `sts:AssumeRole`.
+- One or more **Inference Profile ARNs** already
+[created in AWS Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-create.html).
+
 ## Setting up the AWS Bedrock Inference Profile integration
 
 The script below configures the AWS Bedrock integration in Galileo.
@@ -85,6 +97,45 @@ EOF
 )"
 ```
 
+## Verifying the integration was updated
+
+A successful `PUT` returns a JSON response like this:
+
+```json
+{
+  "id": "a0ce9eff-1290-41ae-b78d-a01118a1122c",
+  "permissions": [],
+  "name": "aws_bedrock",
+  "created_at": "2026-03-20T22:36:57.225940Z",
+  "updated_at": "2026-03-20T22:36:57.225946Z",
+  "created_by": "e19dd8ef-c881-4c17-bc2a-fa549f691a5c",
+  "is_selected": false
+}
+```
+
+A few fields are worth checking:
+
+- `created_by` is the Galileo user that owns this integration. If you have
+multiple users in your organization, this confirms which user's integration
+was just updated.
+- `updated_at` confirms the change was persisted just now.
+
+If the request returns a `4xx` or `5xx` error instead, the integration was
+**not** updated. Resolve the error and re-run the script before testing
+inference again.
+
+## Sharing integrations across users
+
+Each AWS Bedrock integration belongs to the Galileo user who created it.
+Multiple users in the same organization can each create their own AWS Bedrock
+integration, and each one stays associated only with the user who set it up.
+
+A user can also share their integration with other users or with user groups.
+Shared integrations appear in the recipient's Galileo UI labeled as
+**Shared**. To start using a shared integration, the recipient must
+**select** it in the UI. Once selected, they can use it for their inference
+runs.
+
 ## Supported models
 
 Galileo supports all major Amazon Bedrock foundation models, including:
@@ -95,8 +146,26 @@ Galileo supports all major Amazon Bedrock foundation models, including:
 - Amazon Titan
 - Cohere Command
 
-## Requesting a demo or help with setup
+## Troubleshooting
 
-If you'd like to see a demo of the AWS Bedrock Inference Profile Integration
-or need help setting it up, please
-[Request a Demo](https://galileo.ai/contact-sales)
+If you've updated the integration but inference is still using the old
+configuration, walk through this checklist:
+
+- Confirm the `PUT` request returned a success response (see
+[Verifying the integration was updated](#verifying-the-integration-was-updated)),
+not a `4xx` or `5xx` error.
+- Check **which Galileo API key** was used in the script — it corresponds to
+a specific Galileo user.
+- Check **which AWS Role ARN** was used, and verify it has
+`bedrock:InvokeModel` and `sts:AssumeRole` permissions.
+- Check the **model aliases** in the request body. Each one must be a
+Bedrock model alias supported by Galileo (see
+[Supported models](#supported-models)).
+- Check the **inference profile ARNs** in the request body. Each ARN must
+point to an inference profile that exists in your AWS account and that the
+provided IAM role has permission to invoke (`bedrock:InvokeModel` on the
+profile, plus permission to invoke its underlying foundation model).
+- Confirm the integration belonging to the API key's user is the one
+being used for inference.
+- If the integration is shared with other users, confirm those users have
+**selected** the shared integration in the Galileo UI.

--- a/sdk-api/third-party-integrations/model-integrations/custom-model-integrations/custom-model-integrations.mdx
+++ b/sdk-api/third-party-integrations/model-integrations/custom-model-integrations/custom-model-integrations.mdx
@@ -161,11 +161,11 @@ List of built-in model aliases that can be used with `based_on`:
     <Accordion title="Anthropic">
       <AliasesAnthropic />
     </Accordion>
+    <Accordion title="AWS Bedrock">
+      <AliasesBedrock />
+    </Accordion>
     <Accordion title="Azure">
       <AliasesAzure />
-    </Accordion>
-    <Accordion title="Bedrock">
-      <AliasesBedrock />
     </Accordion>
     <Accordion title="Databricks">
       <AliasesDatabricks />

--- a/snippets/code/multilingual/integrations/custom/aliases/aliases-bedrock.mdx
+++ b/snippets/code/multilingual/integrations/custom/aliases/aliases-bedrock.mdx
@@ -15,6 +15,7 @@
 - `Anthropic - Claude Opus 4.1 (Bedrock)`
 - `Anthropic - Claude Opus 4.5 (Bedrock)`
 - `Anthropic - Claude Opus 4.6 (Bedrock)`
+- `Anthropic - Claude Opus 4.7 (Bedrock)`
 - `Anthropic - Claude Sonnet 4.5 (Bedrock)`
 - `Anthropic - Claude Sonnet 4.6 (Bedrock)`
 - `Cohere - Command R v1 (Bedrock)`


### PR DESCRIPTION
This adds clarifying information that I recently shared with a customer to help them troubleshoot AWS Bedrock application inference profile setup.

## Summary
- Add Prerequisites, success-response example, sharing/ownership explanation, and a Troubleshooting checklist to the AWS Bedrock Inference Profiles page so customers can self-serve when updates appear not to take effect.
- Replace the hand-written supported-models list with the shared `AliasesBedrock` snippet so this page and the Custom Model Integrations page stay in sync from a single source.
- Add `Anthropic - Claude Opus 4.7 (Bedrock)` to the alias snippet (it was missing vs. the canonical list).
- On the Custom Model Integrations page, rename the accordion from "Bedrock" to "AWS Bedrock" and reorder it alphabetically before Azure.

## Test plan
- [ ] Build/preview the docs site and visit the AWS Bedrock page; verify the new sections render and the alias list shows via the snippet.
- [ ] Visit the Custom Model Integrations page; verify the accordion is now titled "AWS Bedrock" and appears before "Azure".
- [ ] Confirm the alias list in both places includes Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)