### PR TITLE
feat: update experiment unit test docs to use metric_aggregates

### DIFF
--- a/sdk-api/experiments/running-experiments-in-unit-tests.mdx
+++ b/sdk-api/experiments/running-experiments-in-unit-tests.mdx
@@ -64,9 +64,9 @@ To poll the experiment, you retrieve it by name. If you used a non-unique name w
 <SnippetPythonGetExperimentBeta />
 </CodeGroup>
 
-The returned experiment has an aggregate metrics property that will be set when the metrics have been calculated. This is a dictionary containing the average values, keyed off of `average_<metric_name>`, where `<metric_name>` is the value of the metric used, such as the value of a `GalileoMetrics`, or the name of a custom metric.
+The returned experiment has a `metric_aggregates` property that is populated once all metrics have been calculated. It is a dictionary containing full aggregate statistics for each metric — `avg`, `min`, `max`, `p50`, `p90`, `p95`, and `p99`. Scorer-backed metrics are keyed by scorer UUID; system metrics such as latency and cost use stable string keys.
 
-You can check the returned experiment for this property, and the metrics. If these are not yet set, wait a few seconds, re-get the experiment and check again.
+To look up a metric by its human-readable name, use `experiment.experiment_columns` to build a label-to-key mapping. Check whether `metric_aggregates` is empty and, if so, wait a few seconds, re-fetch the experiment and try again.
 
 <CodeGroup>
 <SnippetPythonPollExperiment />

--- a/sdk-api/experiments/running-experiments-in-unit-tests.mdx
+++ b/sdk-api/experiments/running-experiments-in-unit-tests.mdx
@@ -64,9 +64,9 @@ To poll the experiment, you retrieve it by name. If you used a non-unique name w
 <SnippetPythonGetExperimentBeta />
 </CodeGroup>
 
-The returned experiment has a `metric_aggregates` property that is populated once all metrics have been calculated. It is a dictionary containing full aggregate statistics for each metric — `avg`, `min`, `max`, `p50`, `p90`, `p95`, and `p99`. Scorer-backed metrics are keyed by scorer UUID; system metrics such as latency and cost use stable string keys.
+The returned experiment has a `get_metric_aggregate()` method that returns full aggregate statistics — `avg`, `min`, `max`, `p50`, `p90`, `p95`, `p99` — for a specific metric. Pass a `GalileoMetrics` enum value, a human-readable label, or a metric name string. The method returns `None` when the metric has not yet been calculated.
 
-To look up a metric by its human-readable name, use `experiment.experiment_columns` to build a label-to-key mapping. Check whether `metric_aggregates` is empty and, if so, wait a few seconds, re-fetch the experiment and try again.
+Check whether the metric is `None` and, if so, wait a few seconds, re-fetch the experiment and try again.
 
 <CodeGroup>
 <SnippetPythonPollExperiment />

--- a/snippets/code/python-beta/sdk/experiments/unit-tests/assert-experiment.mdx
+++ b/snippets/code/python-beta/sdk/experiments/unit-tests/assert-experiment.mdx
@@ -1,8 +1,7 @@
 ```python Python (Beta)
-# Use experiment_columns to find the metric UUID for a named metric
-col_map = {col.label: col for col in experiment.experiment_columns}
-correctness_key = col_map["Correctness"].id.removeprefix("metrics/")
+from galileo.schema.metrics import GalileoMetrics
 
-# Assert that the average correctness exceeds a certain threshold
-assert experiment.metric_aggregates[correctness_key].avg >= 0.95
+# Assert that the average metric exceeds a certain threshold
+agg = experiment.get_metric_aggregate(GalileoMetrics.correctness)
+assert agg.avg >= 0.95
 ```

--- a/snippets/code/python-beta/sdk/experiments/unit-tests/assert-experiment.mdx
+++ b/snippets/code/python-beta/sdk/experiments/unit-tests/assert-experiment.mdx
@@ -1,4 +1,8 @@
 ```python Python (Beta)
-# Assert that the average metric exceeds a certain threshold
-assert experiment.aggregate_metrics.get("average_factuality") >= 0.95
+# Use experiment_columns to find the metric UUID for a named metric
+col_map = {col.label: col for col in experiment.experiment_columns}
+correctness_key = col_map["Correctness"].id.removeprefix("metrics/")
+
+# Assert that the average correctness exceeds a certain threshold
+assert experiment.metric_aggregates[correctness_key].avg >= 0.95
 ```

--- a/snippets/code/python-beta/sdk/experiments/unit-tests/poll-experiment.mdx
+++ b/snippets/code/python-beta/sdk/experiments/unit-tests/poll-experiment.mdx
@@ -1,6 +1,5 @@
 ```python Python (Beta)
 import time
-from galileo import Experiment, Metric
 
 # Poll till the experiment is complete
 while not experiment.get_status().is_complete:
@@ -8,8 +7,4 @@ while not experiment.get_status().is_complete:
     time.sleep(5)
     # Refresh experiment to get latest status
     experiment.refresh()
-
-# Access aggregate metrics
-metrics = experiment.aggregate_metrics
-average_correctness = metrics.get(f"average_{Metric.scorers.correctness.value}")
 ```

--- a/snippets/code/python-beta/sdk/experiments/unit-tests/poll-experiment.mdx
+++ b/snippets/code/python-beta/sdk/experiments/unit-tests/poll-experiment.mdx
@@ -1,10 +1,11 @@
 ```python Python (Beta)
 import time
+from galileo.schema.metrics import GalileoMetrics
 
-# Poll till the experiment is complete
-while not experiment.get_status().is_complete:
-    # Sleep for 5 seconds before polling again
+# Poll until the specific metric is computed
+while experiment.get_metric_aggregate(GalileoMetrics.correctness) is None:
+    # Sleep before polling again
     time.sleep(5)
-    # Refresh experiment to get latest status
+    # Refresh the experiment to get the latest results
     experiment.refresh()
 ```

--- a/snippets/code/python/sdk/experiments/unit-tests/assert-experiment.mdx
+++ b/snippets/code/python/sdk/experiments/unit-tests/assert-experiment.mdx
@@ -1,8 +1,7 @@
 ```python Python
-# Use experiment_columns to find the metric UUID for a named metric
-col_map = {col.label: col for col in experiment.experiment_columns}
-correctness_key = col_map["Correctness"].id.removeprefix("metrics/")
+from galileo.schema.metrics import GalileoMetrics
 
-# Assert that the average correctness exceeds a certain threshold
-assert experiment.metric_aggregates[correctness_key].avg >= 0.95
+# Assert that the average metric exceeds a certain threshold
+agg = experiment.get_metric_aggregate(GalileoMetrics.instruction_adherence)
+assert agg.avg >= 0.95
 ```

--- a/snippets/code/python/sdk/experiments/unit-tests/assert-experiment.mdx
+++ b/snippets/code/python/sdk/experiments/unit-tests/assert-experiment.mdx
@@ -1,4 +1,8 @@
 ```python Python
-# Assert that the average metric exceeds a certain threshold
-assert experiment.aggregate_metrics[average_metric_name] >= 0.95
+# Use experiment_columns to find the metric UUID for a named metric
+col_map = {col.label: col for col in experiment.experiment_columns}
+correctness_key = col_map["Correctness"].id.removeprefix("metrics/")
+
+# Assert that the average correctness exceeds a certain threshold
+assert experiment.metric_aggregates[correctness_key].avg >= 0.95
 ```

--- a/snippets/code/python/sdk/experiments/unit-tests/poll-experiment.mdx
+++ b/snippets/code/python/sdk/experiments/unit-tests/poll-experiment.mdx
@@ -1,14 +1,7 @@
 ```python Python
-# Get the name of the average metric
-average_metric_name = f"average_{GalileoMetrics.instruction_adherence.value}"
-
-# Poll till the metrics are calculated
-while (
-    experiment.aggregate_metrics is None
-    or average_metric_name
-        not in experiment.aggregate_metrics
-):
-    # If we don't have the metrics calculated,
+# Poll until the metrics are calculated
+while not experiment.metric_aggregates:
+    # If we don't have the metrics calculated yet,
     # sleep for 5 seconds before polling again
     time.sleep(5)
 

--- a/snippets/code/python/sdk/experiments/unit-tests/poll-experiment.mdx
+++ b/snippets/code/python/sdk/experiments/unit-tests/poll-experiment.mdx
@@ -1,10 +1,11 @@
 ```python Python
-# Poll until the metrics are calculated
-while not experiment.metric_aggregates:
-    # If we don't have the metrics calculated yet,
-    # sleep for 5 seconds before polling again
+from galileo.schema.metrics import GalileoMetrics
+
+# Poll until the specific metric is computed
+while experiment.get_metric_aggregate(GalileoMetrics.instruction_adherence) is None:
+    # If the metric isn't ready yet, sleep before polling again
     time.sleep(5)
 
-    # Reload the experiment to see if we now have the metrics
+    # Reload the experiment to get the latest results
     experiment = get_experiment(experiment_name=experiment_name)
 ```


### PR DESCRIPTION
## Summary

- Replaces deprecated `aggregate_metrics` (flat `average_<name>` keyed dict) with `metric_aggregates` in all experiment unit test code snippets
- Updates the polling pattern to check `not experiment.metric_aggregates` instead of `aggregate_metrics is None` + key check
- Updates the assertion pattern to use `experiment_columns` for UUID→label resolution, then access `.avg` from the `MetricAggregates` object
- Fixes `factuality` → `correctness` metric rename in the python-beta assert snippet
- Updates the prose explanation on the page to describe the new `metric_aggregates` structure (UUID keys, full stats dict, `experiment_columns` for label resolution)

## Dependencies

Depends on SC-64065 (galileo-python PR #578) and SC-64066 (galileo-js PR #591) being merged — those PRs add `metric_aggregates` and `experiment_columns` to both SDKs.

## What's NOT in this PR

The TypeScript reference docs (`sdk-api/typescript/reference/README/**`) are auto-generated from galileo-js TypeDoc on every SDK publish. Those files contain a "Do not edit" notice and will update automatically when SC-64066 merges and publishes.

## Files changed

| File | Change |
|------|--------|
| `snippets/code/python/sdk/experiments/unit-tests/poll-experiment.mdx` | Poll on `not metric_aggregates` instead of `aggregate_metrics is None` + key check |
| `snippets/code/python/sdk/experiments/unit-tests/assert-experiment.mdx` | UUID lookup via `experiment_columns` + `.avg` assertion |
| `snippets/code/python-beta/sdk/experiments/unit-tests/poll-experiment.mdx` | Keep `get_status().is_complete` loop; remove stale `aggregate_metrics` access lines |
| `snippets/code/python-beta/sdk/experiments/unit-tests/assert-experiment.mdx` | UUID lookup via `experiment_columns` + `.avg`; fix `factuality` → `correctness` |
| `sdk-api/experiments/running-experiments-in-unit-tests.mdx` | Update prose describing key format and stats structure |

Closes SC-64068

🤖 Generated with [Claude Code](https://claude.com/claude-code)