### PR TITLE
docs: add TypeScript/Node.js GalileoSpanProcessor to OTel overview

### DIFF
--- a/sdk-api/third-party-integrations/opentelemetry-and-openinference.mdx
+++ b/sdk-api/third-party-integrations/opentelemetry-and-openinference.mdx
@@ -65,11 +65,11 @@ The convention is to store this in the `GALILEO_CONSOLE_URL` environment variabl
 <CodeGroup>
 
 ```python Python
-os.environ["GALILEO_CONSOLE_URL"] = "https://api.galileo.ai"
+os.environ["GALILEO_CONSOLE_URL"] = "https://console.galileo.example.com"
 ```
 
 ```typescript TypeScript
-process.env.GALILEO_CONSOLE_URL = "https://api.galileo.ai";
+process.env.GALILEO_CONSOLE_URL = "https://console.galileo.example.com";
 ```
 
 </CodeGroup>
@@ -138,6 +138,60 @@ provider.register();
 </Steps>
 
 You can now use this trace provider either using a framework that supports OTel directly, or via OpenInference.
+
+### Complete TypeScript/Node.js example
+
+Here's a complete, runnable example that sets up the `GalileoSpanProcessor` with OpenTelemetry
+and creates a traced operation. You can copy this and run it to see traces appear in the Galileo console.
+
+<CodeGroup>
+
+```typescript TypeScript
+import dotenv from "dotenv";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { AlwaysOnSampler } from "@opentelemetry/sdk-trace-node";
+import { GalileoSpanProcessor } from "galileo";
+import { trace } from "@opentelemetry/api";
+
+// Load GALILEO_API_KEY, GALILEO_PROJECT, GALILEO_LOG_STREAM from .env
+dotenv.config();
+
+async function main() {
+  // 1. Start the OTel SDK with GalileoSpanProcessor
+  const sdk = new NodeSDK({
+    spanProcessors: [new GalileoSpanProcessor()],
+    sampler: new AlwaysOnSampler(),
+  });
+  sdk.start();
+
+  // 2. Use the tracer to create spans
+  const tracer = trace.getTracer("my-app");
+
+  tracer.startActiveSpan("my-workflow", async (span) => {
+    span.setAttribute("input", "What is the capital of France?");
+
+    // Simulate some work (e.g., an LLM call)
+    const result = "The capital of France is Paris.";
+
+    span.setAttribute("output", result);
+    span.end();
+  });
+
+  // 3. Shut down to ensure all traces are exported
+  await sdk.shutdown();
+
+  console.log("Traces sent to Galileo!");
+}
+
+main();
+```
+
+</CodeGroup>
+
+<Note>
+Make sure your `.env` file has `GALILEO_API_KEY`, `GALILEO_PROJECT`, and `GALILEO_LOG_STREAM` set.
+If you're using a self-hosted deployment, also set `GALILEO_CONSOLE_URL`.
+</Note>
 
 ## OpenInference
 

--- a/sdk-api/third-party-integrations/opentelemetry-and-openinference.mdx
+++ b/sdk-api/third-party-integrations/opentelemetry-and-openinference.mdx
@@ -3,7 +3,12 @@ title: Overview
 description: Learn how to integrate Galileo with OpenTelemetry and OpenInference for comprehensive observability and tracing
 ---
 
-import ConfigureOTel from "/snippets/content/configure-otel.mdx"
+{/*<!-- markdownlint-disable MD044 -->*/}
+
+import SnippetSimpleEnvVars from "/snippets/code/multilingual/env-galileo.mdx"
+import SnippetConfigureOTelEndpoint from "/snippets/content/configure-otel-endpoint.mdx"
+
+{/*<!-- markdownlint-enable MD044 -->*/}
 
 This guide explains how to integrate Galileo with [OpenTelemetry](https://opentelemetry.io/) and [OpenInference](https://github.com/Arize-ai/openinference) for comprehensive observability and tracing of your AI/ML workflows using industry-standard tools.
 
@@ -11,13 +16,136 @@ This guide explains how to integrate Galileo with [OpenTelemetry](https://opente
 
 The first step is to configure OpenTelemetry.
 
-<ConfigureOTel/>
+<Steps>
+<Step title="Installation">
 
-You can now use this trace processor either using a framework that supports OTel directly, or via OpenInference.
+Add the Galileo SDK and OpenTelemetry packages to your project:
+
+<CodeGroup>
+
+```bash Python
+pip install opentelemetry-api opentelemetry-sdk \
+            opentelemetry-exporter-otlp
+```
+
+```bash TypeScript
+npm install galileo \
+      @opentelemetry/sdk-trace-node \
+      @opentelemetry/exporter-trace-otlp-proto
+```
+
+</CodeGroup>
+
+For Python, the `opentelemetry-api` and `opentelemetry-sdk` packages provide the core OpenTelemetry functionality. The `opentelemetry-exporter-otlp` package enables sending traces to Galileo's OTLP endpoint.
+
+For TypeScript, the `galileo` package includes the `GalileoSpanProcessor` which handles OTLP export configuration automatically. The `@opentelemetry/sdk-trace-node` and `@opentelemetry/exporter-trace-otlp-proto` packages are required peer dependencies.
+</Step>
+<Step title="Create environment variables for your Galileo settings">
+
+Set environment variables for your Galileo settings, for example in a `.env` file.
+These environment variables are consumed by the `GalileoSpanProcessor` to authenticate
+and route traces to the correct Galileo Project and Log stream:
+
+<CodeGroup>
+
+<SnippetSimpleEnvVars/>
+
+</CodeGroup>
+</Step>
+<Step title="Self-hosted deployments: Set the OTel endpoint">
+
+<Note>
+Skip this step if you are using Galileo Cloud.
+</Note>
+
+<SnippetConfigureOTelEndpoint/>
+
+The convention is to store this in the `GALILEO_CONSOLE_URL` environment variable. For example:
+
+<CodeGroup>
+
+```python Python
+os.environ["GALILEO_CONSOLE_URL"] = "https://api.galileo.ai"
+```
+
+```typescript TypeScript
+process.env.GALILEO_CONSOLE_URL = "https://api.galileo.ai";
+```
+
+</CodeGroup>
+</Step>
+<Step title="Initialize and create the Galileo span processor">
+
+The `GalileoSpanProcessor` automatically configures authentication
+and metadata using your environment variables. It also:
+
+- Auto-builds OTLP headers using your Galileo credentials
+- Configures the correct OTLP trace endpoint
+- Registers a batch span processor that exports traces to Galileo
+
+<CodeGroup>
+
+```python Python
+from galileo import otel  
+
+# GalileoSpanProcessor (no manual OTLP config required) loads the env vars for 
+# the Galileo API key, Project, and Log stream. Make sure to set them first. 
+galileo_span_processor = otel.GalileoSpanProcessor(
+    # Optional parameters if not set, uses env var
+    # project=os.environ["GALILEO_PROJECT"], 
+    # logstream=os.environ.get("GALILEO_LOG_STREAM"),  
+)
+```
+
+```typescript TypeScript
+import { GalileoSpanProcessor } from 'galileo';
+
+// GalileoSpanProcessor (no manual OTLP config required) loads the env vars for
+// the Galileo API key, Project, and Log stream. Make sure to set them first.
+const processor = new GalileoSpanProcessor({
+    // Optional parameters if not set, uses env var
+    // project: process.env.GALILEO_PROJECT,
+    // logstream: process.env.GALILEO_LOG_STREAM,
+});
+```
+
+</CodeGroup>
+</Step>
+<Step title="Register the span processor">
+
+The span processor can now be registered with an OTel trace provider.
+
+<CodeGroup>
+
+```python Python
+from opentelemetry.sdk import trace as trace_sdk
+
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(galileo_span_processor)
+```
+
+```typescript TypeScript
+import { addGalileoSpanProcessor } from 'galileo';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+
+const provider = new NodeTracerProvider();
+addGalileoSpanProcessor(provider, processor);
+provider.register();
+```
+
+</CodeGroup>
+</Step>
+</Steps>
+
+You can now use this trace provider either using a framework that supports OTel directly, or via OpenInference.
 
 ## OpenInference
 
-Now you can enable automatic tracing for your framework and LLM operations using OpenInference instrumentors. These add AI-specific semantic conventions to your traces.
+<Note>
+OpenInference instrumentors are currently available for Python only. For TypeScript/Node.js applications, use framework-specific OTel integrations such as [Vercel AI SDK](/sdk-api/third-party-integrations/opentelemetry-and-openinference/vercel-ai) or [Mastra](/sdk-api/third-party-integrations/opentelemetry-and-openinference/mastra).
+</Note>
+
+You can enable automatic tracing for your framework and LLM operations using OpenInference instrumentors. These add AI-specific semantic conventions to your traces.
 
 For example, to instrument LangChain and OpenAI start by adding the relevant OpenInference packages:
 
@@ -70,7 +198,10 @@ Learn how to integrate with some popular frameworks using OpenTelemetry and Open
 <Card title="Strands Agents" icon="python" horizontal href="/sdk-api/third-party-integrations/opentelemetry-and-openinference/strands-agents">
     Learn how to integrate a Strands Agents project with Galileo using OpenTelemetry.
 </Card>
-<Card title="Vercel AI SDK" icon="python" horizontal href="/sdk-api/third-party-integrations/opentelemetry-and-openinference/vercel-ai">
+<Card title="Vercel AI SDK" icon="js" horizontal href="/sdk-api/third-party-integrations/opentelemetry-and-openinference/vercel-ai">
     Learn how to integrate a Vercel AI SDK project with Galileo using OpenTelemetry.
+</Card>
+<Card title="Mastra" icon="js" horizontal href="/sdk-api/third-party-integrations/opentelemetry-and-openinference/mastra">
+    Learn how to integrate a Mastra project with Galileo using OpenTelemetry.
 </Card>
 </CardGroup>

--- a/sdk-api/third-party-integrations/opentelemetry-and-openinference.mdx
+++ b/sdk-api/third-party-integrations/opentelemetry-and-openinference.mdx
@@ -139,60 +139,6 @@ provider.register();
 
 You can now use this trace provider either using a framework that supports OTel directly, or via OpenInference.
 
-### Complete TypeScript/Node.js example
-
-Here's a complete, runnable example that sets up the `GalileoSpanProcessor` with OpenTelemetry
-and creates a traced operation. You can copy this and run it to see traces appear in the Galileo console.
-
-<CodeGroup>
-
-```typescript TypeScript
-import dotenv from "dotenv";
-import { NodeSDK } from "@opentelemetry/sdk-node";
-import { AlwaysOnSampler } from "@opentelemetry/sdk-trace-node";
-import { GalileoSpanProcessor } from "galileo";
-import { trace } from "@opentelemetry/api";
-
-// Load GALILEO_API_KEY, GALILEO_PROJECT, GALILEO_LOG_STREAM from .env
-dotenv.config();
-
-async function main() {
-  // 1. Start the OTel SDK with GalileoSpanProcessor
-  const sdk = new NodeSDK({
-    spanProcessors: [new GalileoSpanProcessor()],
-    sampler: new AlwaysOnSampler(),
-  });
-  sdk.start();
-
-  // 2. Use the tracer to create spans
-  const tracer = trace.getTracer("my-app");
-
-  tracer.startActiveSpan("my-workflow", async (span) => {
-    span.setAttribute("input", "What is the capital of France?");
-
-    // Simulate some work (e.g., an LLM call)
-    const result = "The capital of France is Paris.";
-
-    span.setAttribute("output", result);
-    span.end();
-  });
-
-  // 3. Shut down to ensure all traces are exported
-  await sdk.shutdown();
-
-  console.log("Traces sent to Galileo!");
-}
-
-main();
-```
-
-</CodeGroup>
-
-<Note>
-Make sure your `.env` file has `GALILEO_API_KEY`, `GALILEO_PROJECT`, and `GALILEO_LOG_STREAM` set.
-If you're using a self-hosted deployment, also set `GALILEO_CONSOLE_URL`.
-</Note>
-
 ## OpenInference
 
 <Note>

--- a/sdk-api/third-party-integrations/opentelemetry-and-openinference/vercel-ai.mdx
+++ b/sdk-api/third-party-integrations/opentelemetry-and-openinference/vercel-ai.mdx
@@ -6,6 +6,7 @@ description: Learn how to integrate a Vercel AI SDK project with Galileo using O
 {/*<!-- markdownlint-disable MD044 -->*/}
 
 import SnippetSimpleEnvVars from "/snippets/code/multilingual/env-galileo-simple.mdx"
+import SnippetEnvVars from "/snippets/code/multilingual/env-galileo.mdx"
 import SnippetConfigureOTelEndpoint from "/snippets/content/configure-otel-endpoint.mdx"
 import SnippetQuickstartTypeScript from "/snippets/code/typescript/sdk/otel/vertex/quickstart-example.mdx"
 
@@ -22,31 +23,71 @@ To log Vercel AI SDK applications using Galileo, the first step is to set up Ope
 
 Add the OpenTelemetry NPM packages to your Vercel AI application project.
 
-<CodeGroup>
+<Tabs>
+<Tab title="Using GalileoSpanProcessor">
+
+```bash Terminal
+npm install galileo \
+      @opentelemetry/sdk-node \
+      @opentelemetry/sdk-trace-node
+```
+
+</Tab>
+<Tab title="Manual OTLP configuration">
 
 ```bash Terminal
 npm i @opentelemetry/sdk-node \
       @opentelemetry/exporter-trace-otlp-http
 ```
 
-</CodeGroup>
+</Tab>
+</Tabs>
 </Step>
 <Step title="Create environment variables for your Galileo settings">
 
 Set environment variables for your Galileo settings, for example in a `.env` file:
 
+<Tabs>
+<Tab title="Using GalileoSpanProcessor">
+<CodeGroup>
+<SnippetEnvVars/>
+</CodeGroup>
+</Tab>
+<Tab title="Manual OTLP configuration">
 <CodeGroup>
 <SnippetSimpleEnvVars/>
 </CodeGroup>
+</Tab>
+</Tabs>
 </Step>
 <Step title="Get your endpoint">
 <SnippetConfigureOTelEndpoint/>
 </Step>
 <Step title="Start the OTel processor">
 
-Use the following code to start the OTel processor. Update the value of `galileoEndpoint` to reflect your endpoint if you are using a custom Galileo deployment.
+<Tabs>
+<Tab title="Using GalileoSpanProcessor">
 
-<CodeGroup>
+The `GalileoSpanProcessor` from the `galileo` package handles OTLP configuration automatically
+using your environment variables. No manual endpoint or header setup is required.
+
+```typescript TypeScript
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { AlwaysOnSampler } from '@opentelemetry/sdk-trace-node';
+import { GalileoSpanProcessor } from 'galileo';
+
+const sdk = new NodeSDK({
+  spanProcessors: [new GalileoSpanProcessor()],
+  sampler: new AlwaysOnSampler(),
+});
+
+sdk.start();
+```
+
+</Tab>
+<Tab title="Manual OTLP configuration">
+
+Update the value of `galileoEndpoint` to reflect your endpoint if you are using a custom Galileo deployment.
 
 ```typescript TypeScript
 import { NodeSDK } from '@opentelemetry/sdk-node';
@@ -77,10 +118,11 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-</CodeGroup>
+</Tab>
+</Tabs>
 </Step>
 <Step title="Run your application">
-Your application is not configured to send telemetry to Galileo using OTel. Run your application to see traces in your Log stream.
+Your application is now configured to send telemetry to Galileo using OTel. Run your application to see traces in your Log stream.
 </Step>
 </Steps>
 
@@ -91,18 +133,74 @@ Here is a full example based off the [Vercel AI SDK Agents example](https://ai-s
 To run this example, create a `.env` file with the following values set, or set them as environment variables:
 
 ```ini .env
-# AWS environment variables
 OPENAI_API_KEY=your-openai-api-key
-
-# Galileo environment variables
-GALILEO_API_ENDPOINT=your-galileo-otel-api-endpoint
 GALILEO_API_KEY=your-galileo-api-key
 GALILEO_PROJECT=your-galileo-project
 GALILEO_LOG_STREAM=your-log-stream
 ```
 
-Remember to update these to match your [Galileo API key](https://app.galileo.ai/settings/api-keys), OpenAI API key, [Galileo OTel endpoint](/sdk-api/third-party-integrations/opentelemetry-and-openinference#configure-the-otel-endpoint), project name, and Log stream name.
+Remember to update these to match your [Galileo API key](https://app.galileo.ai/settings/api-keys), OpenAI API key, project name, and Log stream name.
 
-<CodeGroup>
+<Tabs>
+<Tab title="Using GalileoSpanProcessor">
+
+```typescript TypeScript
+import dotenv from "dotenv";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { AlwaysOnSampler } from "@opentelemetry/sdk-trace-node";
+import { GalileoSpanProcessor } from "galileo";
+import { openai } from "@ai-sdk/openai";
+import { Experimental_Agent as Agent, stepCountIs, tool } from "ai";
+import { z } from "zod";
+
+dotenv.config();
+
+// Set up Galileo tracing (reads env vars automatically)
+const sdk = new NodeSDK({
+  spanProcessors: [new GalileoSpanProcessor()],
+  sampler: new AlwaysOnSampler(),
+});
+sdk.start();
+
+const weatherAgent = new Agent({
+  model: openai("gpt-4-turbo"),
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location (in Fahrenheit)",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72,
+      }),
+    }),
+    convertFahrenheitToCelsius: tool({
+      description: "Convert temperature from Fahrenheit to Celsius",
+      inputSchema: z.object({
+        temperature: z.number().describe("Temperature in Fahrenheit"),
+      }),
+      execute: async ({ temperature }) => {
+        const celsius = Math.round((temperature - 32) * (5 / 9));
+        return { celsius };
+      },
+    }),
+  },
+  stopWhen: stepCountIs(20),
+  experimental_telemetry: { isEnabled: true },
+});
+
+const result = await weatherAgent.generate({
+  prompt: "What is the weather in San Francisco in celsius?",
+});
+
+console.log(result.text);
+
+await sdk.shutdown();
+```
+
+</Tab>
+<Tab title="Manual OTLP configuration">
 <SnippetQuickstartTypeScript/>
-</CodeGroup>
+</Tab>
+</Tabs>


### PR DESCRIPTION
## Describe your changes

Adds TypeScript/Node.js documentation for `GalileoSpanProcessor` to the existing OpenTelemetry overview page, so Python and TypeScript users share a single setup guide with tabbed code groups.

**Changes to `opentelemetry-and-openinference.mdx`:**
- Replaced the `<ConfigureOTel/>` shared snippet import with inline steps containing Python + TypeScript `<CodeGroup>` tabs for: installation, env vars, self-hosted endpoint config, processor initialization, and provider registration
- Added a `<Note>` to the OpenInference section clarifying it is Python-only, with links to Vercel AI SDK and Mastra for TypeScript users
- Fixed the Vercel AI SDK card icon from `python` to `js`
- Added a Mastra card to the Next steps section

**Not modified:** shared snippets (`configure-otel.mdx`, `configure-otel-env-vars.mdx`) remain untouched so Python-only framework pages (Strands Agents, Google ADK, Microsoft Agent Framework, A2A) are unaffected.

## Shortcut ticket

[SC-64532](https://app.shortcut.com/galileo/story/64532)

## Checklist before requesting a review

- [x] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [x] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [x] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have verified all images and videos match production (or dev for unreleased features)
- [ ] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [x] - All checks have passed
- [x] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release