### PR TITLE
Redirect legacy /client-reference/observe paths to current SDK reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1214,6 +1214,14 @@
     {
       "source": "/concepts/annotations/annotations-walkthrough",
       "destination": "/concepts/annotations/overview"
+    },
+    {
+      "source": "/client-reference/observe/typescript",
+      "destination": "/sdk-api/typescript/sdk-reference"
+    },
+    {
+      "source": "/client-reference/observe/python",
+      "destination": "/sdk-api/python/sdk-reference"
     }
   ],
   "contextual": {


### PR DESCRIPTION
## Summary

Adds two redirects in `docs.json` so legacy URLs under `/client-reference/observe/` route to the current SDK reference pages:

- `/client-reference/observe/typescript` → `/sdk-api/typescript/sdk-reference`
- `/client-reference/observe/python` → `/sdk-api/python/sdk-reference`

## Why

Both legacy URLs currently 404 but **still appear on the first page of Google search results** when searching for "typescript galileo" and "python galileo" — so new users following the top organic results land on broken pages instead of our SDK docs. Adding these redirects fixes the bounce until Google reindexes.

## Test plan

- [x] `python3 -c "import json; json.load(open('docs.json'))"` — JSON still parses
- [x] Confirmed destination pages exist (`sdk-api/python/sdk-reference.mdx`, `sdk-api/typescript/sdk-reference.mdx`)
- [x] Confirmed no existing redirect already handles these source paths
- [ ] Verify after deploy: visiting `/client-reference/observe/typescript` and `/client-reference/observe/python` routes to the SDK reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)