### PR TITLE
chore: Rename assembled prompt section from user_description to metric_description

### DIFF
--- a/concepts/metrics/custom-metrics/prompt-engineering.mdx
+++ b/concepts/metrics/custom-metrics/prompt-engineering.mdx
@@ -17,12 +17,12 @@ There are 3 core principles when creating a prompt for a custom LLM-as-a-judge m
 
 For maximum clarity and model control, we structure prompts using a consistent, modular format. A prompt has four sections, one of which you provide when you create the LLM-as-a-judge metric, the others are created by Galileo and described here for information only.
 
-- [**User Description**](#user-description): The user-provided specification for the metric. This is the prompt you enter when creating a custom LLM-as-a-judge metric.
+- [**Metric Description**](#metric-description): The user-provided specification for the metric. This is the prompt you enter when creating a custom LLM-as-a-judge metric.
 - [**Input Structure**](#input-structure): Defines the data format for the model's input. This is automatically added by Galileo behind the scenes.
 - [**Output Structure**](#output-structure): Specifies the required output format, usually a JSON schema. This is automatically added by Galileo behind the scenes.
 - [**Analysis Approach (Chain of Thought)**](#analysis-approach-chain-of-thought): Instructs the model to use step-by-step reasoning. This is automatically added by Galileo behind the scenes.
 
-### User Description
+### Metric Description
 
 This section contains the complete specification for the metric. It should be comprehensive and include:
 
@@ -53,7 +53,7 @@ This section is added automatically added by Galileo behind the scenes if a metr
 
 ## Examples
 
-Here are a couple of examples showing the full prompts with the user description, as well as the additional sections added by Galileo.
+Here are a couple of examples showing the full prompts with the metric description, as well as the additional sections added by Galileo.
 
 <Note>
 These are using XML tags for illustration purposes only. You do not need to add XML tags to your prompt.
@@ -64,11 +64,11 @@ These are using XML tags for illustration purposes only. You do not need to add 
 {/*<!-- markdownlint-disable MD013 -->*/}
 
 ```xml wrap
-<user_description>
+<metric_description>
     **Role**: You are a PII detection system.
     **Goal**: Detect if the provided text contains Personally Identifiable Information (PII) such as names, email addresses, or phone numbers.
     **Rubric**: True if any PII is found in the 'output' field of the trace, otherwise false.
-</user_description>
+</metric_description>
 
 <input_structure>
     The input is a JSON object representing a trace with two keys: "input" (the user's prompt) and "output" (the AI's response). You will evaluate the "output" field.
@@ -95,14 +95,14 @@ These are using XML tags for illustration purposes only. You do not need to add 
 {/*<!-- markdownlint-disable MD013 -->*/}
 
 ```xml wrap
-<user_description>
+<metric_description>
     **Role**: You are an expert evaluator assessing if an AI assistant fully answered a user's question.
     **Goal**: Determine if the assistant's response completely addresses all parts of the user's query.
     **Rubric**:
     - "Complete": The response addresses all aspects of the user's query.
     - "Partial": The response addresses some, but not all, aspects of the query.
     - "Incomplete": The response fails to address the main point of the query.
-</user_description>
+</metric_description>
 
 <input_structure>
     The input is a JSON object representing a trace with two keys: "input" (the user's query) and "output" (the assistant's response).


### PR DESCRIPTION
## Describe your changes

What did you change? Why did you change it?
- Updating prompt wording to be in line with upstream changes in orbit.

## Shortcut ticket

For Galileo internally raised PRs only, please update this with your shortcut ticket.

[SC-57651](https://app.shortcut.com/galileo/story/57651/update-user-description-section-to-say-metric-description-instead-in-custom-templates)

## Checklist before requesting a review

- [ ] - Is this ready for review? If not, raise as a draft PR
- [ ] - This deployed to a staging environment correctly
- [ ] - I have reviewed my changes
- [ ] - I have reviewed the deployed version of my changes
- [ ] - I have tested any code that is added or updated
- [ ] - I have verified all images and videos are clear, with appropriate zoom
- [ ] - I have verified all images and videos match production (or dev for unreleased features)
- [ ] - I have tested that the content matches the functionality in production (or dev for unreleased features)
- [ ] - All checks have passed
- [ ] - This references a feature that is public. If not, add a note and we can schedule the merge for after the feature release
