### PR TITLE
fix: replace non-existent galileo.set_api_key() with correct Configuration pattern

### DIFF
--- a/references/faqs/errors.mdx
+++ b/references/faqs/errors.mdx
@@ -124,8 +124,8 @@ Find solutions to errors with the [Galileo API](/sdk-api/overview) below.
   - Or programmatically:
 
     ```python
-    import galileo
-    galileo.set_api_key("your-api-key")
+    from galileo import Configuration
+    Configuration.galileo_api_key = "your-api-key"
     ```
 
 ### Invalid input shape


### PR DESCRIPTION
## Description

The "Missing or invalid API key" error troubleshooting section in `references/faqs/errors.mdx` documented a programmatic API key setter that does not exist in the SDK:

```python
import galileo
galileo.set_api_key("your-api-key")  # ❌ AttributeError
```

Replaced with the correct pattern using the `Configuration` class:

```python
from galileo import Configuration
Configuration.galileo_api_key = "your-api-key"  # ✅
```

Verified against source (`galileo-python/src/galileo/configuration.py`) — `set_api_key` does not exist anywhere in the module. The fix was tested end-to-end against staging: `Configuration.galileo_api_key` authenticates correctly and `Project.list()` returned results successfully.

## Ticket

[SC-68075](https://app.shortcut.com/galileo/story/68075)

## Checklist

- [x] Change verified against SDK source code
- [x] Correct pattern tested end-to-end against staging
- [x] No other files affected (`set_api_key` appeared only in this one location)