### PR TITLE
docs: patch OpenAPI spec to rename auth header to Galileo-API-Key

### DIFF
--- a/.github/workflows/broken-links-check.yaml
+++ b/.github/workflows/broken-links-check.yaml
@@ -17,7 +17,9 @@ jobs:
           node-version: 23
       # Install Mintlify CLI
       - run: npm install -g mint
-      # Generate API docs
-      - run: npx --yes @mintlify/scraping@latest openapi-file https://api.galileo.ai/public/v2/openapi.json -o api-reference
+      # Install dependencies (needed to run the gen:openapi script)
+      - run: npm install
+      # Generate the patched OpenAPI spec used by docs.json
+      - run: npm run gen:openapi
       # Check for broken links
       - run: mint broken-links

--- a/docs.json
+++ b/docs.json
@@ -810,7 +810,7 @@
               {
                 "group": "v2",
                 "openapi": {
-                  "source": "https://api.galileo.ai/public/v2/openapi.json"
+                  "source": "api-reference/openapi.json"
                 }
               }
             ]

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "gen:errors": "node scripts/generate-errors-data.mjs",
     "generate:errors": "node scripts/generate-errors-json.mjs",
-    "predev": "npm run gen:errors",
+    "gen:openapi": "node scripts/patch-openapi.mjs",
+    "predev": "npm run gen:errors && npm run gen:openapi",
     "dev": "mint dev",
-    "prebuild": "npm run gen:errors",
+    "prebuild": "npm run gen:errors && npm run gen:openapi",
     "lint:markdown": "markdownlint-cli2 \"**/*.{md,mdx}\" --config .markdownlint.jsonc",
     "lint:markdown:fix": "markdownlint-cli2 \"**/*.{md,mdx}\" --config .markdownlint.jsonc --fix"
   },

--- a/scripts/patch-openapi.mjs
+++ b/scripts/patch-openapi.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * patch-openapi.mjs
+ *
+ * Fetches the public OpenAPI spec from api.galileo.ai and patches the
+ * APIKeyHeader security scheme's header name from "Splunk-AO-API-Key" to
+ * "Galileo-API-Key" before it's used to generate the API reference docs.
+ * This script runs at build time, NOT runtime.
+ *
+ * Usage: node scripts/patch-openapi.mjs
+ */
+
+import { writeFileSync, mkdirSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Source and destination
+const OPENAPI_URL = 'https://api.galileo.ai/public/v2/openapi.json';
+const OUTPUT_PATH = join(__dirname, '../api-reference/openapi.json');
+
+// Security scheme to patch
+const SCHEME_NAME = 'APIKeyHeader';
+const OLD_HEADER_NAME = 'Splunk-AO-API-Key';
+const NEW_HEADER_NAME = 'Galileo-API-Key';
+
+/**
+ * Fetches the OpenAPI spec from the upstream URL
+ */
+async function fetchSpec() {
+    let response;
+    try {
+        response = await fetch(OPENAPI_URL);
+    } catch (err) {
+        console.error(`❌ Failed to fetch ${OPENAPI_URL}:`, err.message);
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        console.error(`❌ Failed to fetch ${OPENAPI_URL}: ${response.status} ${response.statusText}`);
+        process.exit(1);
+    }
+
+    try {
+        return await response.json();
+    } catch (err) {
+        console.error(`❌ Failed to parse OpenAPI spec as JSON:`, err.message);
+        process.exit(1);
+    }
+}
+
+/**
+ * Patches the APIKeyHeader security scheme's name in place.
+ * Fails loudly if the scheme is missing or has an unexpected value, so an
+ * upstream spec change doesn't silently no-op this patch.
+ */
+function patchSecurityScheme(spec) {
+    const scheme = spec?.components?.securitySchemes?.[SCHEME_NAME];
+
+    if (!scheme) {
+        console.error(`❌ Could not find components.securitySchemes.${SCHEME_NAME} in the fetched spec`);
+        process.exit(1);
+    }
+
+    if (scheme.name === NEW_HEADER_NAME) {
+        // Already patched upstream (or a re-run) - nothing to do
+        return;
+    }
+
+    if (scheme.name !== OLD_HEADER_NAME) {
+        console.error(
+            `❌ components.securitySchemes.${SCHEME_NAME}.name was "${scheme.name}", expected "${OLD_HEADER_NAME}" or "${NEW_HEADER_NAME}". ` +
+            `The upstream spec may have changed - update this script.`
+        );
+        process.exit(1);
+    }
+
+    scheme.name = NEW_HEADER_NAME;
+}
+
+async function main() {
+    const spec = await fetchSpec();
+
+    patchSecurityScheme(spec);
+
+    mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+
+    try {
+        writeFileSync(OUTPUT_PATH, JSON.stringify(spec, null, 2), 'utf8');
+    } catch (err) {
+        console.error(`❌ Failed to write ${OUTPUT_PATH}:`, err.message);
+        process.exit(1);
+    }
+
+    console.log(`✅ Patched ${SCHEME_NAME}.name to "${NEW_HEADER_NAME}" and wrote ${OUTPUT_PATH}`);
+}
+
+main();


### PR DESCRIPTION
https://splunk.atlassian.net/browse/HYBIM-858

## Summary
- The public OpenAPI spec (`https://api.galileo.ai/public/v2/openapi.json`) still documents the API key auth header as `Splunk-AO-API-Key` in `components.securitySchemes.APIKeyHeader`. Since the docs' `/api-reference/*` pages are generated live from that spec, this name leaked into the published API reference and playground.
- Added `scripts/patch-openapi.mjs`, which fetches the spec at build time and structurally renames that header to `Galileo-API-Key`, writing the patched copy to `api-reference/openapi.json` (mirrors the existing `gen:errors` build-time codegen pattern).
- Wired the new `gen:openapi` script into `predev`/`prebuild` in `package.json`, and pointed `docs.json`'s `openapi.source` at the local patched file instead of the remote URL.
- Updated `.github/workflows/broken-links-check.yaml` to generate the patched spec before running `mint broken-links`, so CI validates against the same content that ships.

## Test plan
- [x] `node scripts/patch-openapi.mjs` generates `api-reference/openapi.json` with `Galileo-API-Key` present and `Splunk-AO-API-Key` absent; other security schemes untouched.
- [x] Re-running the script is idempotent.
- [x] `package.json` and `docs.json` remain valid JSON.
- [ ] `npm run dev` locally and confirm `/api-reference/datasets/create-dataset` shows `Galileo-API-Key` in the auth section/playground.
- [ ] Confirm CI's broken-links workflow passes with the new generation step.
- [ ] After merge, confirm the deployed docs render `Galileo-API-Key` (validates that Mintlify's hosted build runs `prebuild`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)